### PR TITLE
Update all references to pystorm

### DIFF
--- a/examples/drpc/README.md
+++ b/examples/drpc/README.md
@@ -1,10 +1,10 @@
-# Install pystorm
+# Install streamparse
 
-In the pystorm directory, run
+In the streamparse directory, run
 
     sudo python setup.py develop
 
-In order to have the `pystorm` shell command available system-wide.
+In order to have the `sparse` shell command available system-wide.
 
 
 # Install Leiningen
@@ -19,4 +19,4 @@ On OSX you can also use homebrew to install leiningen
 
     lein deps
     lein compile
-    lein run -m pystorm.AdderTopology
+    lein run -m streamparse.AdderTopology

--- a/examples/drpc/multilang/resources/adder.py
+++ b/examples/drpc/multilang/resources/adder.py
@@ -1,6 +1,6 @@
 import re
 
-from pystorm.bolt import BasicBolt
+from streamparse.bolt import BasicBolt
 
 
 class AdderBolt(BasicBolt):

--- a/examples/drpc/project.clj
+++ b/examples/drpc/project.clj
@@ -1,4 +1,4 @@
-(defproject pystorm-example-drpc "0.0.1-SNAPSHOT"
+(defproject streamparse-example-drpc "0.0.1-SNAPSHOT"
   :source-paths ["src/clj"]
   :java-source-paths ["src/jvm"]
   :test-paths ["test/jvm"]

--- a/examples/drpc/src/jvm/pystorm/AdderTopology.java
+++ b/examples/drpc/src/jvm/pystorm/AdderTopology.java
@@ -1,4 +1,4 @@
-package pystorm;
+package streamparse;
 
 import java.util.Map;
 

--- a/examples/wordcount/README.md
+++ b/examples/wordcount/README.md
@@ -1,10 +1,10 @@
-# Install pystorm
+# Install streamparse
 
-In the pystorm directory, run
+In the streamparse directory, run
 
     sudo python setup.py develop
 
-In order to have the `pystorm` shell command available system-wide.
+In order to have the `sparse` shell command available system-wide.
 
 
 # Install Leiningen
@@ -19,4 +19,4 @@ On OSX you can also use homebrew to install leiningen
 
     lein deps
     lein compile
-    lein run -m pystorm.word-count
+    lein run -m streamparse.word-count

--- a/examples/wordcount/multilang/resources/sentence_splitter.py
+++ b/examples/wordcount/multilang/resources/sentence_splitter.py
@@ -1,4 +1,4 @@
-from pystorm.bolt import BasicBolt
+from streamparse.bolt import BasicBolt
 
 
 class SentenceSplitterBolt(BasicBolt):

--- a/examples/wordcount/multilang/resources/sentence_spout.py
+++ b/examples/wordcount/multilang/resources/sentence_spout.py
@@ -1,7 +1,6 @@
-import logging
 import random
 
-from pystorm.spout import Spout
+from streamparse.spout import Spout
 
 
 class SentenceSpout(Spout):

--- a/examples/wordcount/multilang/resources/word_count.py
+++ b/examples/wordcount/multilang/resources/word_count.py
@@ -1,6 +1,6 @@
 from collections import defaultdict
 
-from pystorm.bolt import BasicBolt
+from streamparse.bolt import BasicBolt
 
 
 class WordCountBolt(BasicBolt):

--- a/examples/wordcount/project.clj
+++ b/examples/wordcount/project.clj
@@ -1,4 +1,4 @@
-(defproject pystorm-example-wordcount "0.0.1-SNAPSHOT"
+(defproject streamparse-example-wordcount "0.0.1-SNAPSHOT"
   :source-paths ["src/clj"]
   :java-source-paths ["src/jvm"]
   :test-paths ["test/jvm"]

--- a/examples/wordcount/src/clj/pystorm/word_count.clj
+++ b/examples/wordcount/src/clj/pystorm/word_count.clj
@@ -1,4 +1,4 @@
-(ns pystorm.word-count
+(ns streamparse.word-count
   (:import [backtype.storm StormSubmitter LocalCluster])
   (:use [backtype.storm clojure config])
   (:gen-class))
@@ -8,7 +8,7 @@
   (topology
     ;; spout configuration
     {"sentences" (shell-spout-spec
-        ;; call pystorm sentence_spout.py (sentence_spout.py included in multilang/resources/sentence_spout.py)
+        ;; call streamparse sentence_spout.py (sentence_spout.py included in multilang/resources/sentence_spout.py)
         "python" "sentence_spout.py"
         ;; output fields
         ["sentence"]
@@ -18,7 +18,7 @@
     {"words" (shell-bolt-spec
         ;; indicates bolt uses a grouping of tuples from stream 1 on field "word"
         {"sentences" :shuffle}
-        ;; call pystorm word_count (word_count.py included in multilang/resources/word_count.py)
+        ;; call streamparse word_count (word_count.py included in multilang/resources/word_count.py)
         "python" "sentence_splitter.py"
         ;; output fields
         ["word"])

--- a/streamparse/ext/__init__.py
+++ b/streamparse/ext/__init__.py
@@ -1,1 +1,1 @@
-"""pystorm.ext package"""
+"""streamparse.ext package"""


### PR DESCRIPTION
The examples say "pystorm" all over the place, which I'm assuming is an old name for `streamparse`. I found that very confusing as a beginner, so I've fixed that. I'm not sure if the rest of the steps in the README files are up-to-date though.
