### PR TITLE
Fix remaining Python 3 compatibility issue

### DIFF
--- a/streamparse/ext/util.py
+++ b/streamparse/ext/util.py
@@ -67,7 +67,7 @@ def get_env_config(env_name=None):
     """
     config = get_config()
     if env_name is None and len(config["envs"]) == 1:
-        env_name = config["envs"].keys()[0]
+        env_name = list(config["envs"].keys())[0]
     elif env_name is None and len(config["envs"]) > 1:
         die("Found more than one environment in config.json. "
             "When more than one environment exists, you must "
@@ -85,7 +85,7 @@ def get_nimbus_for_env_config(env_config):
     config file.
     """
     if not env_config["nimbus"]:
-        die("No Nimbus server configured for in config.json.")
+        die("No Nimbus server configured in config.json.")
 
     if ":" in env_config["nimbus"]:
         host, port = env_config["nimbus"].split(":", 1)


### PR DESCRIPTION
It wasn't until today that I ran `sparse list` on a streamparse project (I've mostly been using the bolt implementation so far) and encountered an issue with trying to index into a `dict_keys` object. That's fixed now.

I also removed an extra preposition in an error message.
