### PR TITLE
Add flush method to LogStream

### DIFF
--- a/streamparse/ipc.py
+++ b/streamparse/ipc.py
@@ -75,6 +75,12 @@ class LogStream(object):
             sys.stdout = sys.__stdout__
             sys.stderr = sys.__stderr__
             raise
+        
+    def flush(self):
+        """No-op method to prevent crashes when someone does 
+        sys.stdout.flush.
+        """
+        pass
 
 
 class Tuple(object):


### PR DESCRIPTION
I ran into an issue where a Bolt I was using that tried to flush stdout was crashing because it's not implemented in LogStream. This should fix that problem.
