### PR TITLE
Add StormHandler for logging

### DIFF
--- a/streamparse/base.py
+++ b/streamparse/base.py
@@ -17,6 +17,7 @@ _STORM_LOG_LEVELS = {
     'debug': _STORM_LOG_DEBUG,
     'info': _STORM_LOG_INFO,
     'warn': _STORM_LOG_WARN,
+    'warning': _STORM_LOG_WARN,
     'error': _STORM_LOG_ERROR,
 }
 


### PR DESCRIPTION
I was updating a bunch of code to use Storm for logging instead of Python logging, and I was noticing a substantial performance degradation, since the logging level was only being checked on the Storm side.  

This patch adds a `StormHandler` class that can be used to quickly update any Python code to send logging messages to Storm.
