### PR TITLE
Adds --wait flag to `sparse kill` to specify custom wait time prior to killing topology. 

### DIFF
--- a/jvm/src/streamparse/commands/kill_topology.clj
+++ b/jvm/src/streamparse/commands/kill_topology.clj
@@ -30,7 +30,7 @@
   (let [[opts args banner]
          (cli args
               ["-h" "--help" "Show this help screen." :flag true :default false]
-              ["-w" "--wait" "Amount of time to wait for topology to gracefully stop." :default 10 :parse-fn #(Integer/parseInt %)]
+              ["-w" "--wait" "Amount of time to wait for topology to gracefully stop." :parse-fn #(Integer/parseInt %)]
               ["-n" "--host" "Hostname for Nimbus." :default "localhost"]
               ["-p" "--port" "Port for Nimbus." :default 6627 :parse-fn #(Integer/parseInt %)])]
     (when (or (not= (count args) 1) (:help opts))

--- a/streamparse/cmdln.py
+++ b/streamparse/cmdln.py
@@ -32,7 +32,7 @@ def main():
         sparse run [-n <topology>] [-o <option>]... [-p <par>] [-t <time>] [-dv]
         sparse submit [-n <topology>] [-o <option>]... [-p <par>] [-e <env>] [-dvf]
         sparse list [-e <env>] [-v]
-        sparse kill [-n <topology>] [-e <env>] [-v]
+        sparse kill [-n <topology>] [-e <env>] [-v] [--wait <seconds>]
         sparse tail [-e <env>] [-n <topology>] [--pattern <regex>]
         sparse visualize [-n <topology>] [--flip]
         sparse (-h | --help)
@@ -68,6 +68,7 @@ def main():
         --pattern <regex>           Apply pattern to files for "tail"
                                     subcommand.
         --flip                      Flip the visualization to be horizontal.
+        --wait <seconds>            Seconds to wait before killing topology.
         -f --force                  Force a topology to submit by killing any
                                     currently running topologies of the same
                                     name.
@@ -83,7 +84,7 @@ def main():
     elif args["list"]:
         list_topologies(args["--environment"])
     elif args["kill"]:
-        kill_topology(args["--name"], args["--environment"])
+        kill_topology(args["--name"], args["--environment"], args["--wait"])
     elif args["quickstart"]:
         quickstart(args['<project_name>'])
     elif args["submit"]:

--- a/streamparse/ext/invoke.py
+++ b/streamparse/ext/invoke.py
@@ -99,26 +99,30 @@ def list_topologies(env_name="prod"):
         return _list_topologies()
 
 
-def _kill_topology(topology_name, run_args=None, run_kwargs=None):
+def _kill_topology(topology_name, wait, run_args=None, run_kwargs=None):
     if run_args is None:
         run_args = []
     if run_kwargs is None:
         run_kwargs = {}
     run_kwargs['pty'] = True
-    cmd = ["lein",
-           "run -m streamparse.commands.kill_topology/-main",
-           topology_name]
-    return run(" ".join(cmd), *run_args, **run_kwargs)
+    wait_arg = ("--wait %s" % wait) if wait is not None else ""
+    cmd = ("lein run -m streamparse.commands.kill_topology/-main"
+           " %(topology_name)s %(wait)s") % \
+        {
+            "topology_name": topology_name,
+            "wait": wait_arg
+        }
+    return run(cmd, *run_args, **run_kwargs)
 
 
 @task
-def kill_topology(topology_name=None, env_name="prod"):
+def kill_topology(topology_name=None, env_name="prod", wait=None):
     topology_name, topology_file = get_topology_definition(topology_name)
     env_name, env_config = get_env_config(env_name)
     host, port = get_nimbus_for_env_config(env_config)
 
     with ssh_tunnel(env_config["user"], host, 6627, port):
-        return _kill_topology(topology_name)
+        return _kill_topology(topology_name, wait)
 
 
 @task

--- a/streamparse/ext/invoke.py
+++ b/streamparse/ext/invoke.py
@@ -105,13 +105,13 @@ def _kill_topology(topology_name, wait, run_args=None, run_kwargs=None):
     if run_kwargs is None:
         run_kwargs = {}
     run_kwargs['pty'] = True
-    wait_arg = ("--wait %s" % wait) if wait is not None else ""
+    wait_arg = ("--wait {wait}".format(wait=wait)) if wait is not None else ""
     cmd = ("lein run -m streamparse.commands.kill_topology/-main"
-           " %(topology_name)s %(wait)s") % \
-        {
-            "topology_name": topology_name,
-            "wait": wait_arg
-        }
+           " {topology_name} {wait}") \
+        .format(
+            topology_name=topology_name,
+            wait=wait_arg
+        )
     return run(cmd, *run_args, **run_kwargs)
 
 


### PR DESCRIPTION
Currently streamparse hard codes the kill time to 10 seconds. By default, Storm will use the time set in `topology.message.timeout.secs`. This removes the 10 second default and allows the user to override the Strom default, as desired. 

Command looks like:

```
sparse kill -n topo -e env --wait 30
```

It would probably make sense for me to add a similar option to `sparse submit` since it calls kill, as needed.