### PR TITLE
Adds --wait flag to `sparse submit`.

### DIFF
--- a/streamparse/cmdln.py
+++ b/streamparse/cmdln.py
@@ -30,7 +30,7 @@ def main():
     Usage:
         sparse quickstart <project_name>
         sparse run [-n <topology>] [-o <option>]... [-p <par>] [-t <time>] [-dv]
-        sparse submit [-n <topology>] [-o <option>]... [-p <par>] [-e <env>] [-dvf]
+        sparse submit [-n <topology>] [-o <option>]... [-p <par>] [-e <env>] [-dvf] [--wait <seconds>]
         sparse list [-e <env>] [-v]
         sparse kill [-n <topology>] [-e <env>] [-v] [--wait <seconds>]
         sparse tail [-e <env>] [-n <topology>] [--pattern <regex>]
@@ -91,7 +91,7 @@ def main():
         par = int(args["--par"])
         options = args["--option"]
         submit_topology(args["--name"], args["--environment"], par, options,
-                        args["--force"], args["--debug"])
+                        args["--force"], args["--debug"], args["--wait"])
     elif args["tail"]:
         tail_topology(args["--name"], args["--environment"], args["--pattern"])
     elif args["visualize"]:

--- a/streamparse/ext/invoke.py
+++ b/streamparse/ext/invoke.py
@@ -184,7 +184,7 @@ def run_local_topology(name=None, time=5, par=2, options=None, debug=False):
 
 @task(pre=["prepare_topology"])
 def submit_topology(name=None, env_name="prod", par=2, options=None,
-                    force=False, debug=False):
+                    force=False, debug=False, wait=None):
     """Submit a topology to a remote Storm cluster."""
     prepare_topology()
 
@@ -222,7 +222,7 @@ def submit_topology(name=None, env_name="prod", par=2, options=None,
 
         if force and not is_safe_to_submit(name):
             print("Killing current \"{}\" topology.".format(name))
-            _kill_topology(name, run_kwargs={"hide": "both"})
+            _kill_topology(name, run_kwargs={"hide": "both"}, wait=wait)
             while not is_safe_to_submit(name):
                 print("Waiting for topology {} to quit...".format(name))
                 time.sleep(0.5)


### PR DESCRIPTION
Same functionality as --wait on `sparse kill`. Override the default
time to allow the active topology to live prior to killing.

Irrelevant if topology isn't currently running.

Comparable to what was merged in #92.