### PR TITLE
Split --par into 2 options

### DIFF
--- a/streamparse/cmdln.py
+++ b/streamparse/cmdln.py
@@ -29,8 +29,8 @@ def main():
 
     Usage:
         sparse quickstart <project_name>
-        sparse run [-n <topology>] [-o <option>]... [-p <par>] [-t <time>] [-dv]
-        sparse submit [-n <topology>] [-o <option>]... [-p <par>] [-e <env>] [-dvf]
+        sparse run [-n <topology>] [-o <option>]... [-p <par>] [-w <workers>] [-a <ackers>] [-t <time>] [-dv]
+        sparse submit [-n <topology>] [-o <option>]... [-p <par>] [-w <workers>] [-a <ackers>] [-e <env>] [-dvf]
         sparse list [-e <env>] [-v]
         sparse kill [-n <topology>] [-e <env>] [-v] [--wait <seconds>]
         sparse tail [-e <env>] [-n <topology>] [--pattern <regex>]
@@ -63,6 +63,10 @@ def main():
         -p --par <par>              Parallelism of topology; conveniently sets
                                     number of Storm workers and acker bolts
                                     at once to passed value [default: 2].
+        -a --ackers <ackers>        Set number of acker bolts. Takes precedence 
+                                    over --par if both set.
+        -w --workers <workers>      Set number of Storm workers. Takes 
+                                    precedence over --par if both set.
         -t --time <time>            Time (in seconds) to keep local cluster
                                     running [default: 5].
         --pattern <regex>           Apply pattern to files for "tail"
@@ -79,8 +83,11 @@ def main():
     if args["run"]:
         time = int(args["--time"])
         par = int(args["--par"])
+        ackers = int(args["--ackers"]) if args.get("--ackers") else par
+        workers = int(args["--workers"]) if args.get("--workers") else par
         options = args["--option"]
-        run_local_topology(args["--name"], time, par, options, args["--debug"])
+        run_local_topology(args["--name"], time, workers, ackers, options, 
+                           args["--debug"])
     elif args["list"]:
         list_topologies(args["--environment"])
     elif args["kill"]:
@@ -89,9 +96,11 @@ def main():
         quickstart(args['<project_name>'])
     elif args["submit"]:
         par = int(args["--par"])
+        ackers = int(args["--ackers"]) if args["--ackers"] else par
+        workers = int(args["--workers"]) if args["--workers"] else par
         options = args["--option"]
-        submit_topology(args["--name"], args["--environment"], par, options,
-                        args["--force"], args["--debug"])
+        submit_topology(args["--name"], args["--environment"], workers, ackers, 
+                        options, args["--force"], args["--debug"])
     elif args["tail"]:
         tail_topology(args["--name"], args["--environment"], args["--pattern"])
     elif args["visualize"]:

--- a/streamparse/cmdln.py
+++ b/streamparse/cmdln.py
@@ -63,9 +63,9 @@ def main():
         -p --par <par>              Parallelism of topology; conveniently sets
                                     number of Storm workers and acker bolts
                                     at once to passed value [default: 2].
-        -a --ackers <ackers>        Set number of acker bolts. Takes precedence 
+        -a --ackers <ackers>        Set number of acker bolts. Takes precedence
                                     over --par if both set.
-        -w --workers <workers>      Set number of Storm workers. Takes 
+        -w --workers <workers>      Set number of Storm workers. Takes
                                     precedence over --par if both set.
         -t --time <time>            Time (in seconds) to keep local cluster
                                     running [default: 5].
@@ -83,10 +83,10 @@ def main():
     if args["run"]:
         time = int(args["--time"])
         par = int(args["--par"])
-        ackers = int(args["--ackers"]) if args.get("--ackers") else par
-        workers = int(args["--workers"]) if args.get("--workers") else par
+        ackers = int(args.get("--ackers", par))
+        workers = int(args.get("--workers", par))
         options = args["--option"]
-        run_local_topology(args["--name"], time, workers, ackers, options, 
+        run_local_topology(args["--name"], time, workers, ackers, options,
                            args["--debug"])
     elif args["list"]:
         list_topologies(args["--environment"])
@@ -96,10 +96,10 @@ def main():
         quickstart(args['<project_name>'])
     elif args["submit"]:
         par = int(args["--par"])
-        ackers = int(args["--ackers"]) if args["--ackers"] else par
-        workers = int(args["--workers"]) if args["--workers"] else par
+        ackers = int(args.get("--ackers", par))
+        workers = int(args.get("--workers", par))
         options = args["--option"]
-        submit_topology(args["--name"], args["--environment"], workers, ackers, 
+        submit_topology(args["--name"], args["--environment"], workers, ackers,
                         options, args["--force"], args["--debug"])
     elif args["tail"]:
         tail_topology(args["--name"], args["--environment"], args["--pattern"])

--- a/streamparse/ext/invoke.py
+++ b/streamparse/ext/invoke.py
@@ -147,7 +147,8 @@ def jar_for_deploy():
 
 
 @task(pre=["prepare_topology"])
-def run_local_topology(name=None, time=5, par=2, options=None, debug=False):
+def run_local_topology(name=None, time=5, workers=2, ackers=2, options=None, 
+                       debug=False):
     """Run a topology locally using Storm's LocalCluster class."""
     prepare_topology()
 
@@ -159,8 +160,8 @@ def run_local_topology(name=None, time=5, par=2, options=None, debug=False):
     cmd.append("-t {}".format(time))
     if debug:
         cmd.append("--debug")
-    cmd.append("--option 'topology.workers={}'".format(par))
-    cmd.append("--option 'topology.acker.executors={}'".format(par))
+    cmd.append("--option 'topology.workers={}'".format(workers))
+    cmd.append("--option 'topology.acker.executors={}'".format(ackers))
 
     # Python logging settings
     if not os.path.isdir("logs"):
@@ -183,8 +184,8 @@ def run_local_topology(name=None, time=5, par=2, options=None, debug=False):
 
 
 @task(pre=["prepare_topology"])
-def submit_topology(name=None, env_name="prod", par=2, options=None,
-                    force=False, debug=False):
+def submit_topology(name=None, env_name="prod", workers=2, ackers=2, 
+                    options=None, force=False, debug=False):
     """Submit a topology to a remote Storm cluster."""
     prepare_topology()
 
@@ -240,8 +241,8 @@ def submit_topology(name=None, env_name="prod", par=2, options=None,
                topology_file]
         if debug:
             cmd.append("--debug")
-        cmd.append("--option 'topology.workers={}'".format(par))
-        cmd.append("--option 'topology.acker.executors={}'".format(par))
+        cmd.append("--option 'topology.workers={}'".format(workers))
+        cmd.append("--option 'topology.acker.executors={}'".format(ackers))
         cmd.append("--option 'topology.python.path=\"{}\"'".format(python_path))
 
         # Python logging settings


### PR DESCRIPTION
Addresses issue #74.

Creates new arguments for run and submit. Tested with sparse run.
```
        -p --par <par>              Parallelism of topology; conveniently sets
                                    number of Storm workers and acker bolts
                                    at once to passed value [default: 2].
        -a --ackers <ackers>        Set number of acker bolts. Takes precedence 
                                    over --par if both set.
        -w --workers <workers>      Set number of Storm workers. Takes 
                                    precedence over --par if both set.
```