### PR TITLE
Do not require SSH tunnels

### DIFF
--- a/doc/source/quickstart.rst
+++ b/doc/source/quickstart.rst
@@ -427,6 +427,7 @@ in our ``config.json`` file:
                     "backup_count": 10,
                     "level": "info"
                 },
+                "ssh_tunnel": true,
                 "virtualenv_root": "/data/virtualenvs/"
             }
         }
@@ -458,6 +459,13 @@ these explicitly. streamparse will now:
 1. Package up a JAR containing all your Python source files
 2. Build a virtualenv on all your Storm workers (in parallel)
 3. Submit the topology to the ``nimbus`` server
+
+Local Clusters
+^^^^^^^^^^^^^^
+
+Streamparse assumes that your Storm cluster is not on your local machine. If it 
+is, such as the case with VMs or Docker images, change ``"ssh_tunnel"`` in 
+``config.json`` to ``false``.
 
 Logging
 ^^^^^^^

--- a/streamparse/contextmanagers.py
+++ b/streamparse/contextmanagers.py
@@ -27,6 +27,7 @@ def _port_in_use(port, server_type="tcp"):
 
 @contextmanager
 def ssh_tunnel(user, host, local_port, remote_port):
+    """Opens SSH tunnel to run commands in"""
     if _port_in_use(local_port):
         raise Exception("Local port: {} already in use, unable to open ssh "
                         "tunnel to {}:{}."
@@ -50,3 +51,12 @@ def ssh_tunnel(user, host, local_port, remote_port):
         yield
     finally:
         ssh_proc.terminate()
+
+@contextmanager
+def manage_connection(tunnel, user, host, local_port, remote_port):
+    """Determines if a SSH tunnel is required, and if so, open one"""
+    if tunnel:
+        with ssh_tunnel(user, host, local_port, remote_port):
+            yield
+    else:
+        yield

--- a/streamparse/ext/invoke.py
+++ b/streamparse/ext/invoke.py
@@ -22,7 +22,7 @@ from tempfile import NamedTemporaryFile
 from invoke import run, task
 from six import string_types
 
-from ..contextmanagers import ssh_tunnel
+from ..contextmanagers import manage_connection
 from .util import (get_env_config, get_topology_definition,
                    get_nimbus_for_env_config, get_config)
 from .fabric import activate_env, create_or_update_virtualenvs, tail_logs
@@ -95,7 +95,8 @@ def list_topologies(env_name="prod"):
     env_name, env_config = get_env_config(env_name)
     host, port = get_nimbus_for_env_config(env_config)
 
-    with ssh_tunnel(env_config["user"], host, 6627, port):
+    with manage_connection(env_config.get("ssh_tunnel", True),
+                           env_config["user"], host, 6627, port):
         return _list_topologies()
 
 
@@ -121,7 +122,8 @@ def kill_topology(topology_name=None, env_name="prod", wait=None):
     env_name, env_config = get_env_config(env_name)
     host, port = get_nimbus_for_env_config(env_config)
 
-    with ssh_tunnel(env_config["user"], host, 6627, port):
+    with manage_connection(env_config.get("ssh_tunnel", True),
+                           env_config["user"], host, 6627, port):
         return _kill_topology(topology_name, wait)
 
 
@@ -216,8 +218,9 @@ def submit_topology(name=None, env_name="prod", par=2, options=None,
     topology_jar = jar_for_deploy()
 
     print('Deploying "{}" topology...'.format(name))
-    with ssh_tunnel(env_config["user"], host, 6627, port):
-        print("ssh tunnel to Nimbus {}:{} established."
+    with manage_connection(env_config.get("ssh_tunnel", True),
+                           env_config["user"], host, 6627, port):
+        print("connection to Nimbus {}:{} established."
               .format(host, port))
 
         if force and not is_safe_to_submit(name):


### PR DESCRIPTION
Addresses #96 by letting users customize whether ssh tunnels are needed. SSH tunnels are used by default.

To run commands without tunnels, update `config.json` to have `"ssh_tunnel": false` in the environment setup.

Tested with a localhost setup. Don't have a Docker setup to test but seems like it should work since the services are just exposed over ports.
```
>sparse submit
...
Deploying "wordcount" topology...
connection to Nimbus 127.0.0.1:6627 established.

>sparse list
1022 [main] INFO  backtype.storm.thrift - Connecting to Nimbus at localhost:6627

|     :name | :status | :num-workers | :num-executors | :num-tasks | :uptime-secs |
|-----------+---------+--------------+----------------+------------+--------------|
| wordcount |  ACTIVE |            2 |              5 |          5 |           20 |

>sparse kill
1047 [main] INFO  backtype.storm.thrift - Connecting to Nimbus at localhost:6627
Killed topology:  wordcount

>sparse list
2266 [main] INFO  backtype.storm.thrift - Connecting to Nimbus at localhost:6627
No topologies running.
```