### PR TITLE
Fixing typo in config name to get maxbytes

### DIFF
--- a/streamparse/ipc.py
+++ b/streamparse/ipc.py
@@ -212,7 +212,7 @@ def read_handshake():
     log_path = _conf.get('streamparse.log.path')
     if log_path:
         root_log = logging.getLogger()
-        max_bytes = _conf.get('stremparse.log.max_bytes', 1000000)  # 1 MB
+        max_bytes = _conf.get('streamparse.log.max_bytes', 1000000)  # 1 MB
         backup_count = _conf.get('streamparse.log.backup_count', 10)
         log_file = ('{log_path}/streamparse_{topology_name}_{component_name}_'
                     '{task_id}_{pid}.log'


### PR DESCRIPTION
There's a typo when looking up the maxbytes value in the config file.  (Which causes all streamparse logs to max at 1Mb before rotating.)