### PR TITLE
Don't require SSH tunnels and Fabric for list/kill/submit commands

### DIFF
--- a/jvm/src/streamparse/commands/submit_topology.clj
+++ b/jvm/src/streamparse/commands/submit_topology.clj
@@ -66,6 +66,8 @@
                      TOPOLOGY-WORKERS 2
                      TOPOLOGY-ACKER-EXECUTORS 2
                      TOPOLOGY-MAX-SPOUT-PENDING 5000
+                     NIMBUS-HOST (:host opts)
+                     NIMBUS-THRIFT-PORT (:port opts)
                      TOPOLOGY-MESSAGE-TIMEOUT-SECS 60}
           ;; overlay provided options
           options (merge defaults (:option opts))

--- a/streamparse/ext/invoke.py
+++ b/streamparse/ext/invoke.py
@@ -54,10 +54,11 @@ def get_user_tasks():
         return None, None
 
 
-def is_safe_to_submit(topology_name):
+def is_safe_to_submit(topology_name, host=None, port=None):
     """Check to see if a topology is currently running or is in the process of
     being killed. Assumes tunnel is already connected to Nimbus."""
-    result = _list_topologies(run_kwargs={"hide": "both"})
+    result = _list_topologies(run_kwargs={"hide": "both"},
+                              host=host, port=port)
 
     if result.failed:
         raise Exception("Error running streamparse.commands.list/-main")
@@ -244,12 +245,12 @@ def submit_topology(name=None, env_name="prod", par=2, options=None,
 
 
 def _kill_existing_topology(topology_name, force, wait, host=None, port=None):
-    if force and not is_safe_to_submit(topology_name):
+    if force and not is_safe_to_submit(topology_name, host=host, port=port):
         print("Killing current \"{}\" topology.".format(topology_name))
 
         _kill_topology(topology_name, run_kwargs={"hide": "both"},
                        wait=wait, host=host, port=port)
-        while not is_safe_to_submit(topology_name):
+        while not is_safe_to_submit(topology_name, host=host, port=port):
             print("Waiting for topology {} to quit...".format(topology_name))
             time.sleep(0.5)
         print("Killed.")

--- a/streamparse/ext/invoke.py
+++ b/streamparse/ext/invoke.py
@@ -25,7 +25,7 @@ from six import string_types
 from ..contextmanagers import ssh_tunnel
 from .util import (get_env_config, get_topology_definition,
                    get_nimbus_for_env_config, get_config,
-                   is_ssh_access_for_nimbus)
+                   check_if_use_ssh_for_nimbus)
 from .fabric import activate_env, create_or_update_virtualenvs, tail_logs
 
 
@@ -100,7 +100,7 @@ def list_topologies(env_name="prod"):
     env_name, env_config = get_env_config(env_name)
     host, port = get_nimbus_for_env_config(env_config)
 
-    if is_ssh_access_for_nimbus(env_config):
+    if check_if_use_ssh_for_nimbus(env_config):
         with ssh_tunnel(env_config["user"], host, 6627, port):
             return _list_topologies()
     return _list_topologies(host=host, port=port)
@@ -134,7 +134,7 @@ def kill_topology(topology_name=None, env_name="prod", wait=None):
     env_name, env_config = get_env_config(env_name)
     host, port = get_nimbus_for_env_config(env_config)
 
-    if is_ssh_access_for_nimbus(env_config):
+    if check_if_use_ssh_for_nimbus(env_config):
         with ssh_tunnel(env_config["user"], host, 6627, port):
             return _kill_topology(topology_name, wait)
     return _kill_topology(topology_name, wait, host=host, port=port)
@@ -182,7 +182,7 @@ def run_local_topology(name=None, time=5, par=2, options=None, debug=False):
     log_path = os.path.join(os.getcwd(), "logs")
     print("Routing Python logging to {}.".format(log_path))
     cmd.append("--option 'streamparse.log.path=\"{}\"'"
-                   .format(log_path))
+               .format(log_path))
     cmd.append("--option 'streamparse.log.level=\"debug\"'")
 
 

--- a/streamparse/ext/util.py
+++ b/streamparse/ext/util.py
@@ -98,7 +98,7 @@ def get_nimbus_for_env_config(env_config):
     return (host, port)
 
 
-def check_if_use_ssh_for_nimbus(env_config):
+def is_ssh_for_nimbus(env_config):
     """Check if we need to use SSH access to Nimbus or not.
     """
     return env_config.get('use_ssh_for_nimbus', True)

--- a/streamparse/ext/util.py
+++ b/streamparse/ext/util.py
@@ -96,3 +96,11 @@ def get_nimbus_for_env_config(env_config):
         port = 6627
 
     return (host, port)
+
+
+def is_ssh_access_for_nimbus(env_config):
+    """Check if we need to use SSH access to Nimbus or not.
+    """
+    if 'is_ssh_access_for_nimbus' in env_config:
+        return env_config['is_ssh_access_for_nimbus']
+    return True

--- a/streamparse/ext/util.py
+++ b/streamparse/ext/util.py
@@ -101,6 +101,4 @@ def get_nimbus_for_env_config(env_config):
 def is_ssh_access_for_nimbus(env_config):
     """Check if we need to use SSH access to Nimbus or not.
     """
-    if 'is_ssh_access_for_nimbus' in env_config:
-        return env_config['is_ssh_access_for_nimbus']
-    return True
+    return env_config.get('is_ssh_access_for_nimbus', True)

--- a/streamparse/ext/util.py
+++ b/streamparse/ext/util.py
@@ -98,7 +98,7 @@ def get_nimbus_for_env_config(env_config):
     return (host, port)
 
 
-def is_ssh_access_for_nimbus(env_config):
+def check_if_use_ssh_for_nimbus(env_config):
     """Check if we need to use SSH access to Nimbus or not.
     """
-    return env_config.get('is_ssh_access_for_nimbus', True)
+    return env_config.get('use_ssh_for_nimbus', True)


### PR DESCRIPTION
This PR is directly related with #96, it should solve the issue with SSH tunnels and Fabric requirements for the cases when we don't need it at all, particularly for the Docker case.

I added 2 additional boolean settings for `config.json`:
- `use_ssh_for_nimbus` defines if we need to setup SSH tunnel to talk with Nimbus or we can just use Storm Thrift interface directly at the specified host-port pair
- `use_virtualenv` defines if we need to activate and setup virtualenv (we can miss it if we want to avoid `Fabric` usage and everything needed is already installed and configured at supervisor nodes).
Both values are `true` by default, according to the current library behaviour.

From other changes: 
1) tried to simplify `submit_topology()` function with saving all logic precisely.
2) fixed passing Nimbus host/port to `StormSubmitter/submitTopology`.

The corner case of this solution is that post_submit hooks are executing w/o SSH tunnel now (it's pretty obvious if we don't use it at all).

Any feedback is highly appreciated.