### PR TITLE
Fixed a spout small typo error

### DIFF
--- a/streamparse/storm/spout.py
+++ b/streamparse/storm/spout.py
@@ -166,7 +166,7 @@ class Spout(Component):
 
         Subclasses should **not** override this method.
         """
-        storm_conf, context = read_handshake()
+        storm_conf, context = self.read_handshake()
         self._setup_component(storm_conf, context)
 
         try:


### PR DESCRIPTION
Check it, please. Also something is wrong with last changes in `master` branch, even `wordcount` topology hangs for me now, w/o any errors, could you check it too please? I'll investigate it deeper and open an issue if I find something interesting.