### PR TITLE
Fixed updated bolt/spout imports

### DIFF
--- a/doc/source/quickstart.rst
+++ b/doc/source/quickstart.rst
@@ -285,7 +285,7 @@ Let's create a spout that emits sentences until the end of time:
 
     import itertools
 
-    from streamparse.spout import Spout
+    from streamparse.storm import Spout
 
 
     class SentenceSpout(Spout):
@@ -322,7 +322,7 @@ Now let's create a bolt that takes in sentences, and spits out words:
 
     import re
 
-    from streamparse.bolt import Bolt
+    from streamparse.storm import Bolt
 
     class SentenceSplitterBolt(Bolt):
 
@@ -361,13 +361,13 @@ Bolt Configuration Options
 You can disable the automatic acknowleding, anchoring or failing of tuples by
 adding class variables set to false for: ``auto_ack``, ``auto_anchor`` or
 ``auto_fail``.  All three options are documented in
-:class:`streamparse.bolt.Bolt`.
+:class:`streamparse.storm.Bolt`.
 
 **Example**:
 
 .. code-block:: python
 
-    from streamparse.bolt import Bolt
+    from streamparse.storm import Bolt
 
     class MyBolt(Bolt):
 
@@ -395,13 +395,13 @@ Bolt class. Once this is overridden, you can set the storm option
 to be emitted every ``<frequency>`` seconds.
 
 You can see the full docs for ``process_tick()`` in
-:class:`streamparse.bolt.Bolt`. 
+:class:`streamparse.storm.Bolt`.
 
 **Example**:
 
 .. code-block:: python
 
-    from streamparse.bolt import Bolt
+    from streamparse.storm import Bolt
 
     class MyBolt(Bolt):
 

--- a/examples/drpc/multilang/resources/adder.py
+++ b/examples/drpc/multilang/resources/adder.py
@@ -1,6 +1,6 @@
 import re
 
-from streamparse.bolt import BasicBolt
+from streamparse.storm import BasicBolt
 
 
 class AdderBolt(BasicBolt):

--- a/examples/kafka-jvm/src/bolts/pixel_count.py
+++ b/examples/kafka-jvm/src/bolts/pixel_count.py
@@ -1,7 +1,7 @@
 import datetime as dt
 from collections import Counter
 
-from streamparse.bolt import BatchingBolt
+from streamparse.storm import BatchingBolt
 
 
 class PixelCounterBolt(BatchingBolt):

--- a/examples/kafka-jvm/src/bolts/pixel_deserializer.py
+++ b/examples/kafka-jvm/src/bolts/pixel_deserializer.py
@@ -1,7 +1,7 @@
 import logging
 
 import simplejson as json
-from streamparse.bolt import Bolt
+from streamparse.storm import Bolt
 
 
 class PixelDeserializerBolt(Bolt):

--- a/examples/redis/src/wordcount_mem.py
+++ b/examples/redis/src/wordcount_mem.py
@@ -1,8 +1,8 @@
 from itertools import cycle
 from collections import Counter
 
-from streamparse.spout import Spout
-from streamparse.bolt import Bolt
+from streamparse.storm import Spout
+from streamparse.storm import Bolt
 
 
 class WordSpout(Spout):

--- a/examples/redis/src/wordcount_redis.py
+++ b/examples/redis/src/wordcount_redis.py
@@ -3,8 +3,8 @@ from itertools import cycle
 from collections import Counter
 import os
 
-from streamparse.spout import Spout
-from streamparse.bolt import Bolt
+from streamparse.storm import Spout
+from streamparse.storm import Bolt
 
 
 class WordSpout(Spout):

--- a/streamparse/bootstrap/project/src/bolts/wordcount.py
+++ b/streamparse/bootstrap/project/src/bolts/wordcount.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import, print_function, unicode_literals
 
 from collections import Counter
-from streamparse.bolt import Bolt
+from streamparse.storm import Bolt
 
 
 class WordCounter(Bolt):

--- a/streamparse/storm/bolt.py
+++ b/streamparse/storm/bolt.py
@@ -41,7 +41,7 @@ class Bolt(Component):
 
     .. code-block:: python
 
-        from streamparse.bolt import Bolt
+        from streamparse.storm import Bolt
 
         class SentenceSplitterBolt(Bolt):
 
@@ -307,7 +307,7 @@ class BatchingBolt(Bolt):
 
     .. code-block:: python
 
-        from streamparse.bolt import BatchingBolt
+        from streamparse.storm import BatchingBolt
 
         class WordCounterBolt(BatchingBolt):
 


### PR DESCRIPTION
I fixed some wrong imports (after your reorg). Basic `wordcount` topology still doesn't work for me (even after today fixes), is it only for me, could you check please?