### PR TITLE
Added support for picklable types in tuples.

### DIFF
--- a/streamparse/serialize.py
+++ b/streamparse/serialize.py
@@ -1,0 +1,27 @@
+import pickle
+import zlib
+from base64 import b64encode, b64decode
+
+
+def encode(obj):
+    pickled = pickle.dumps(obj)
+    compressed = zlib.compress(pickled)
+
+    # Ensures that we use the smallest possible form.
+    if len(compressed) < len(pickled):
+        label = '_pyobj_zlib'
+        content = compressed
+    else:
+        label = '_pyobj'
+        content = pickled
+
+    return {label: b64encode(content)}
+
+
+def decode(dct):
+    if '_pyobj_zlib' in dct:
+        return pickle.loads(zlib.decompress(b64decode(dct['_pyobj_zlib'])))
+    elif '_pyobj' in dct:
+        return pickle.loads(b64decode(dct['_pyobj']))
+    else:
+        return dct

--- a/streamparse/storm/component.py
+++ b/streamparse/storm/component.py
@@ -15,6 +15,8 @@ try:
 except ImportError:
     import json
 
+from .. import serialize
+
 
 # Support for Storm Log levels as per STORM-414
 _STORM_LOG_TRACE = 0
@@ -281,7 +283,7 @@ class Component(object):
             msg = '{}{}\n'.format(msg, line[0:-1])
 
         try:
-            return json.loads(msg)
+            return json.loads(msg, object_hook=serialize.decode)
         except Exception:
             log.error("JSON decode error for message: %r", msg, exc_info=True)
             raise
@@ -330,7 +332,8 @@ class Component(object):
                        self.component_name, self.pid, message)
             return
 
-        wrapped_msg = "{}\nend\n".format(json.dumps(message)).encode('utf-8')
+        serialized_msg = json.dumps(message, default=serialize.encode)
+        wrapped_msg = "{}\nend\n".format(serialized_msg).encode('utf-8')
 
         with self._writer_lock:
             self.output_stream.flush()


### PR DESCRIPTION
Allows users to use any picklable Python type within a tuple (for example datetime). I originally was thinking of allowing users to specify custom JSON encoders/decoders but I couldn't think of nice way to pass these custom functions in.