### PR TITLE
Pass virtualenv command-line flags from config.

### DIFF
--- a/doc/source/quickstart.rst
+++ b/doc/source/quickstart.rst
@@ -497,12 +497,20 @@ these explicitly. streamparse will now:
 2. Build a virtualenv on all your Storm workers (in parallel)
 3. Submit the topology to the ``nimbus`` server
 
-Disabling Virtualenv Creation
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Disabling & Configuring Virtualenv Creation
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 If you do not have ssh access to all of the servers in your Storm cluster, but
 you know they have all of the requirements for your Python code installed, you
 can set ``"use_virtualenv"`` to ``false`` in ``config.json``.
+
+If you would like to pass command-line flags to virtualenv, you can set
+``"virtualenv_flags"`` in ``config.json``, for example::
+
+    "virtualenv_flags": "-p /path/to/python"
+
+Note that this only applies when the virtualenv is created, not when an
+existing virtualenv is used.
 
 Using unofficial versions of Storm
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/streamparse/cli/submit.py
+++ b/streamparse/cli/submit.py
@@ -22,7 +22,7 @@ from .update_virtualenv import create_or_update_virtualenvs
 from ..contextmanagers import ssh_tunnel
 from ..util import (activate_env, get_config, get_env_config,
                     get_nimbus_for_env_config, get_topology_definition,
-                    is_ssh_for_nimbus, prepare_topology)
+                    is_ssh_for_nimbus)
 
 
 def get_user_tasks():

--- a/streamparse/cli/submit.py
+++ b/streamparse/cli/submit.py
@@ -178,9 +178,11 @@ def submit_topology(name=None, env_name="prod", workers=2, ackers=2,
 
     if use_venv:
         config["virtualenv_specs"] = config["virtualenv_specs"].rstrip("/")
-        create_or_update_virtualenvs(env_name, name,
-                                     "{}/{}.txt".format(config["virtualenv_specs"],
-                                                        name))
+        create_or_update_virtualenvs(
+            env_name,
+            name,
+            "{}/{}.txt".format(config["virtualenv_specs"], name),
+            virtualenv_flags=env_config.get('virtualenv_flags'))
 
     # Prepare a JAR that doesn't have Storm dependencies packaged
     topology_jar = jar_for_deploy(simple_jar=simple_jar)

--- a/streamparse/cli/update_virtualenv.py
+++ b/streamparse/cli/update_virtualenv.py
@@ -23,7 +23,7 @@ def _create_or_update_virtualenv(virtualenv_root,
                                  virtualenv_flags=None):
     virtualenv_path = os.path.join(virtualenv_root, virtualenv_name)
     if not exists(virtualenv_path):
-        if not virtualenv_flags:
+        if virtualenv_flags is None:
             virtualenv_flags = ''
         puts("virtualenv not found in {}, creating one.".format(virtualenv_root))
         run("virtualenv {} {}".format(virtualenv_path, virtualenv_flags))


### PR DESCRIPTION
I tested this with the wordcount quickstart with the following config.json patch, verifying manually only that the virtualenv was created correctly.

```diff
8,9c8,9
<             "nimbus": "",
<             "workers": [],
---
>             "nimbus": "localhost",
>             "workers": ["localhost"],
16c16,17
<             "virtualenv_root": ""
---
>             "virtualenv_root": "./",
>             "virtualenv_flags": "-p `which pypy`"
19c20
< }
```

Fix #94. #55 is related.