### PR TITLE
Embed PyCon 2015 presentation video in docs.

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -23,6 +23,12 @@ Integrates with Apache Storm.
 
 .. image:: https://raw.githubusercontent.com/Parsely/streamparse/master/doc/source/images/quickstart.gif
 
+.. raw:: html
+
+   <!-- Wrap YouTube embed in a div to get auto-sizing, ref: https://github.com/rtfd/readthedocs.org/issues/879 -->
+   <div style="position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden; max-width: 100%; height: auto;">
+     <iframe src="https://www.youtube.com/embed/ja4Qj9-l6WQ?start=94" frameborder="0" allowfullscreen style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;"></iframe>
+   </div>
 
 Indices and tables
 ==================


### PR DESCRIPTION
Embed @amontalenti's PyCon talk into the front page.

This builds locally if you'd like to preview it. I considered adding headers/context, but the gif and YouTube embed speak for themselves.