### PR TITLE
Document parallelism according to streamparse.

### DIFF
--- a/doc/source/develop.rst
+++ b/doc/source/develop.rst
@@ -21,14 +21,14 @@ To do this, add a directory called ``checkouts`` and symlink it up::
     ln -s ../../../streamparse/jvm streamparse
     cd ..
 
-Now, comment out the ``com.parsely/streamparse`` dependency in ``project.clj``. 
+Now, comment out the ``com.parsely/streamparse`` dependency in ``project.clj``.
 It will now pick up the Clojure commands from your local repo. So, now you can
 tweak and change them!
 
 Local pip installation
 ----------------------
 
-In your virtualenv for this project, go into ``~/repos/streamparse`` (where you 
+In your virtualenv for this project, go into ``~/repos/streamparse`` (where you
 cloned streamparse) and simply run::
 
     python setup.py develop
@@ -47,7 +47,7 @@ Installing Storm pre-releases
 
 You can clone Storm from Github here::
 
-    git clone git@github.com:apache/storm.git 
+    git clone git@github.com:apache/storm.git
 
 There are tags available for releases, e.g.::
 

--- a/doc/source/faq.rst
+++ b/doc/source/faq.rst
@@ -4,11 +4,20 @@ Frequently Asked Questions (FAQ)
 General Questions
 -----------------
 
+* `Why use streamparse?`_
 * `Is streamparse compatible with Python 3?`_
 * `How can I contribute to streamparse?`_
 * `How do I trigger some code before or after I submit my topology?`_
 * `How should I install streamparse on the cluster nodes?`_
 * `Should I install Clojure?`_
+
+Why use streamparse?
+~~~~~~~~~~~~~~~~~~~~
+
+To lay your Python code out in topologies which can be automatically
+parallelized in a Storm cluster of machines. This lets you scale your
+computation horizontally and avoid issues related to Python's GIL. See
+:ref:`parallelism`.
 
 Is streamparse compatible with Python 3?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/source/quickstart.rst
+++ b/doc/source/quickstart.rst
@@ -169,7 +169,7 @@ function named "wordcount".
       ]
     )
 
-It turns out, the name of the function doesn't matter much; we've used 
+It turns out, the name of the function doesn't matter much; we've used
 ``wordcount`` above, but it could just as easily be ``bananas``. What is
 important, is that **the function must return an array with only two
 dictionaries and take one argument**.
@@ -395,7 +395,7 @@ Bolt class. Once this is overridden, you can set the storm option
 to be emitted every ``<frequency>`` seconds.
 
 You can see the full docs for ``process_tick()`` in
-:class:`streamparse.bolt.Bolt`. 
+:class:`streamparse.bolt.Bolt`.
 
 **Example**:
 

--- a/doc/source/quickstart.rst
+++ b/doc/source/quickstart.rst
@@ -214,7 +214,8 @@ run the class provided.  We've also let Storm know exactly what these spouts
 will be emitting, namely a single field called ``sentence``.
 
 You'll notice that in ``sentence-spout-1``, we've passed an optional map of
-configuration parameters ``:p 2``, we'll get back to this later.
+configuration parameters ``:p 2``, which sets the spout to have 2 Python
+processes. This is discussed in :ref:`parallelism`.
 
 Creating bolts is very similar and uses the ``python-bolt-spec`` function:
 

--- a/doc/source/quickstart.rst
+++ b/doc/source/quickstart.rst
@@ -264,9 +264,9 @@ but you will most commonly use a **shuffle** or **fields** grouping:
 * **Shuffle grouping**: Tuples are randomly distributed across the bolt’s tasks
   in a way such that each bolt is guaranteed to get an equal number of tuples.
 * **Fields grouping**: The stream is partitioned by the fields specified in the
-  grouping. For example, if the stream is grouped by the “user-id” field,
-  tuples with the same “user-id” will always go to the same task, but tuples
-  with different “user-id”’s may go to different tasks.
+  grouping. For example, if the stream is grouped by the "user-id" field,
+  tuples with the same "user-id" will always go to the same task, but tuples
+  with different "user-id"’s may go to different tasks.
 
 There are more options to configure with spouts and bolts, we'd encourage you
 to refer to `Storm's Concepts

--- a/doc/source/topologies.rst
+++ b/doc/source/topologies.rst
@@ -238,12 +238,10 @@ standard lein project file and can be customized according to your needs.
 Parallelism and Workers
 -----------------------
 
-Reference: `Understanding the Parallelism of a Storm Topology <https://storm.apache.org/documentation/Understanding-the-parallelism-of-a-Storm-topology.html>`_
-
 **In general, use the :p "parallelism hint" parameter per spout and bolt in
-your configuration to control the number of Python processes per
-component. When getting started, let streamparse set the default number of
-topology workers, then tune once you observe specific bottlenecks.**
+your configuration to control the number of Python processes per component.**
+
+Reference: `Understanding the Parallelism of a Storm Topology <https://storm.apache.org/documentation/Understanding-the-parallelism-of-a-Storm-topology.html>`_
 
 Storm parallelism entities:
 

--- a/doc/source/topologies.rst
+++ b/doc/source/topologies.rst
@@ -229,5 +229,3 @@ If you submitted to a cluster, streamparse uses ``lein`` to compile the ``src``
 directory into a jar file, which is run on the cluster. Lein uses the
 ``project.clj`` file located in the root of your project. This file is a
 standard lein project file and can be customized according to your needs.
-
-

--- a/doc/source/topologies.rst
+++ b/doc/source/topologies.rst
@@ -204,9 +204,9 @@ but you will most commonly use a **shuffle** or **fields** grouping:
 * **Shuffle grouping**: Tuples are randomly distributed across the bolt’s tasks
   in a way such that each bolt is guaranteed to get an equal number of tuples.
 * **Fields grouping**: The stream is partitioned by the fields specified in the
-  grouping. For example, if the stream is grouped by the “user-id” field,
-  tuples with the same “user-id” will always go to the same task, but tuples
-  with different “user-id”’s may go to different tasks.
+  grouping. For example, if the stream is grouped by the "user-id" field,
+  tuples with the same "user-id" will always go to the same task, but tuples
+  with different "user-id"’s may go to different tasks.
 
 
 Running Topologies

--- a/doc/source/topologies.rst
+++ b/doc/source/topologies.rst
@@ -193,6 +193,8 @@ The ``python-bolt-spec`` takes at least 4 arguments:
 4. A list of the named fields the spout will output
 5. Any optional keyword arguments, such as parallelism ``:p 2``
 
+Parallelism is further discussed in :ref:`parallelism`.
+
 
 Groupings
 ^^^^^^^^^
@@ -229,3 +231,57 @@ If you submitted to a cluster, streamparse uses ``lein`` to compile the ``src``
 directory into a jar file, which is run on the cluster. Lein uses the
 ``project.clj`` file located in the root of your project. This file is a
 standard lein project file and can be customized according to your needs.
+
+
+.. _parallelism:
+
+Parallelism and Workers
+-----------------------
+
+Reference: `Understanding the Parallelism of a Storm Topology <https://storm.apache.org/documentation/Understanding-the-parallelism-of-a-Storm-topology.html>`_
+
+**In general, use the :p "parallelism hint" parameter per spout and bolt in
+your configuration to control the number of Python processes per
+component. When getting started, let streamparse set the default number of
+topology workers, then tune once you observe specific bottlenecks.**
+
+Storm parallelism entities:
+
+* A `worker process` is a JVM, i.e. a Java process.
+* An `executor` is a thread that is spawned by a worker process.
+* A `task` performs the actual data processing.
+  (To simplify, you can think of it as a Python callable.)
+
+Spout and bolt specs take a ``:p`` keyword to provide a parallelism hint to
+Storm for the number of executors (threads) to use for the given spout/bolt;
+for example, ``:p 2`` is a hint to use two executors. Because streamparse
+implements spouts and bolts as independent Python processes, setting ``:p N``
+results in N Python processes for the given spout/bolt.
+
+Many streamparse applications will need only to set this parallelism hint to
+control the number of resulting Python processes when tuning streamparse
+configuration. For the underlying topology workers, streamparse sets a default
+of 2 workers, which are independent JVM processes for Storm. This allows a
+topology to continue running when one worker process dies; the other is around
+until the dead process restarts.
+
+Both ``sparse run`` and ``sparse sumbit`` accept a ``-p N`` command-line flag
+to set the number of topology workers to N. For convenience, this flag also
+sets the number of `Storm's underlying messaging reliability
+<https://storm.apache.org/documentation/Guaranteeing-message-processing.html>`_
+`acker bolts` to the same N value. In the event that you need it (and you
+understand Storm ackers), use the ``-a`` and ``-w`` command-line flags instead
+of ``-p`` to control the number of acker bolts and the number of workers,
+respectively. The ``sparse`` command does not support Storm's rebalancing
+features; use ``sparse submit -f -p N`` to kill the running topology and
+redeploy it with N workers.
+
+Note that `Storm's underlying thread implementation
+<https://storm.apache.org/2012/08/02/storm080-released.html>`_, `LMAX Disruptor
+<http://lmax-exchange.github.io/disruptor/>`_, is designed with
+high-performance inter-thread messaging as a goal. Rule out Python-level issues
+when tuning your topology:
+
+* bottlenecks where the number of spout and bolt processes are out of balance
+* serialization/deserialization overhead of more data emitted than you need
+* slow routines/callables in your code


### PR DESCRIPTION
Fix #163. For @amontalenti to review, cc: @dan-blanchard. This document combines and simplifies much previous discussion, nearly all of which was ad hoc or decentralized. I've taken this approach with the doc:

1. Clearly explain parallelism according to streamparse, namely that the "parallelism hint" controls the number of Python processes.
2. Express an opinion on how most users should configure streamparse, unless they know what they are doing.
3. Explain and reference enough about Storm to help users know what they are doing.

I fixed the missing reference for `:p 2` in the quickstart along the way.

You can preview a rendered doc on GitHub [here](https://github.com/Parsely/streamparse/blob/79b591057eb428b2686fa464dc83fe0601230a79/doc/source/topologies.rst#parallelism-and-workers).