### PR TITLE
Touchup docs for consistency of Storm references.

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -27,7 +27,7 @@ Integrates with Apache Storm.
 
    <!-- Wrap YouTube embed in a div to get auto-sizing, ref: https://github.com/rtfd/readthedocs.org/issues/879 -->
    <div style="position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden; max-width: 100%; height: auto;">
-     <iframe src="https://www.youtube.com/embed/ja4Qj9-l6WQ?start=94" frameborder="0" allowfullscreen style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;"></iframe>
+     <iframe src="https://www.youtube.com/embed/ja4Qj9-l6WQ?start=94" frameborder="0" allowfullscreen style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; padding-bottom: 1em;"></iframe>
    </div>
 
 Indices and tables

--- a/doc/source/quickstart.rst
+++ b/doc/source/quickstart.rst
@@ -90,7 +90,7 @@ streamparse projects expect to have the following directory layout:
     "project.clj","leiningen project file, can be used to add external JVM dependencies."
     "src/","Python source files (bolts/spouts/etc.) for topologies."
     "tasks.py","Optional custom invoke tasks."
-    "topologies/","Contains topology definitions written using the `Clojure DSL <http://storm.incubator.apache.org/documentation/Clojure-DSL.html>`_ for Storm."
+    "topologies/","Contains topology definitions written using the `Clojure DSL <http://storm.apache.org/documentation/Clojure-DSL.html>`_ for Storm."
     "virtualenvs/","Contains pip requirements files in order to install dependencies on remote Storm servers."
 
 
@@ -169,7 +169,7 @@ function named "wordcount".
       ]
     )
 
-It turns out, the name of the function doesn't matter much; we've used 
+It turns out, the name of the function doesn't matter much; we've used
 ``wordcount`` above, but it could just as easily be ``bananas``. What is
 important, is that **the function must return an array with only two
 dictionaries and take one argument**.
@@ -258,7 +258,7 @@ sources for the bolt. It's completely fine to add multiple sources to any bolts.
 In the ``word-counter`` bolt, we've told Storm that we'd like the stream of
 input tuples to be grouped by the named field ``word``. Storm offers
 comprehensive options for `stream groupings
-<http://storm.incubator.apache.org/documentation/Concepts.html#stream-groupings>`_,
+<http://storm.apache.org/documentation/Concepts.html#stream-groupings>`_,
 but you will most commonly use a **shuffle** or **fields** grouping:
 
 * **Shuffle grouping**: Tuples are randomly distributed across the bolt’s tasks
@@ -270,7 +270,7 @@ but you will most commonly use a **shuffle** or **fields** grouping:
 
 There are more options to configure with spouts and bolts, we'd encourage you
 to refer to `Storm's Concepts
-<http://storm.incubator.apache.org/documentation/Concepts.html>`_ for more
+<http://storm.apache.org/documentation/Concepts.html>`_ for more
 information.
 
 Spouts and Bolts
@@ -395,7 +395,7 @@ Bolt class. Once this is overridden, you can set the storm option
 to be emitted every ``<frequency>`` seconds.
 
 You can see the full docs for ``process_tick()`` in
-:class:`streamparse.bolt.Bolt`. 
+:class:`streamparse.bolt.Bolt`.
 
 **Example**:
 

--- a/doc/source/topologies.rst
+++ b/doc/source/topologies.rst
@@ -198,7 +198,7 @@ Groupings
 ^^^^^^^^^
 
 Storm offers comprehensive options for `stream groupings
-<http://storm.incubator.apache.org/documentation/Concepts.html#stream-groupings>`_,
+<http://storm.apache.org/documentation/Concepts.html#stream-groupings>`_,
 but you will most commonly use a **shuffle** or **fields** grouping:
 
 * **Shuffle grouping**: Tuples are randomly distributed across the bolt’s tasks

--- a/doc/source/topologies.rst
+++ b/doc/source/topologies.rst
@@ -44,7 +44,7 @@ take up multiple lines.
 Topology Files
 --------------
 A topology file describes your topology in terms of Directed Acyclic Graph (DAC)
-of Storm components, namely Bolts and Spouts. It uses the
+of Storm components, namely `bolts` and `spouts`. It uses the
 `Clojure DSL <http://storm.apache.org/documentation/Clojure-DSL.html>`_ for
 this, along with some utility functions streamparse provides.
 
@@ -229,5 +229,3 @@ If you submitted to a cluster, streamparse uses ``lein`` to compile the ``src``
 directory into a jar file, which is run on the cluster. Lein uses the
 ``project.clj`` file located in the root of your project. This file is a
 standard lein project file and can be customized according to your needs.
-
-

--- a/streamparse/cli/submit.py
+++ b/streamparse/cli/submit.py
@@ -29,7 +29,7 @@ def get_user_tasks():
     """Get tasks defined in a user's tasks.py and fabric.py file which is
     assumed to be in the current working directory.
 
-    :returns: tuple invoke_tasks, fabric_tasks
+    :returns: a `tuple` (invoke_tasks, fabric_tasks)
     """
     sys.path.insert(0, os.getcwd())
     try:

--- a/streamparse/dsl/bolt.py
+++ b/streamparse/dsl/bolt.py
@@ -38,7 +38,7 @@ class BoltSpecification(Specification):
         self.group_on = group_on
 
     def resolve_dependencies(self, specifications):
-        """Modifies the Bolt's sources to be references to other Specification
+        """Modifies the bolt's sources to be references to other Specification
         objects. Also ensures that group_on fields are provided by the
         source Specifications.
 

--- a/streamparse/storm/bolt.py
+++ b/streamparse/storm/bolt.py
@@ -21,17 +21,17 @@ class Bolt(Component):
     `Concepts documentation <http://storm.incubator.apache.org/documentation/Concepts.html>`_.
 
     :ivar auto_anchor: A ``bool`` indicating whether or not the bolt should
-                       automatically anchor emits to the incoming tuple ID.
+                       automatically anchor emits to the incoming Tuple ID.
                        Tuple anchoring is how Storm provides reliability, you
                        can read more about
-                       `tuple anchoring in Storm's docs <https://storm.incubator.apache.org/documentation/Guaranteeing-message-processing.html#what-is-storms-reliability-api>`_.
+                       `Tuple anchoring in Storm's docs <https://storm.incubator.apache.org/documentation/Guaranteeing-message-processing.html#what-is-storms-reliability-api>`_.
                        Default is ``True``.
 
     :ivar auto_ack: A ``bool`` indicating whether or not the bolt should
-                    automatically acknowledge tuples after ``process()``
+                    automatically acknowledge Tuples after ``process()``
                     is called. Default is ``True``.
     :ivar auto_fail: A ``bool`` indicating whether or not the bolt should
-                     automatically fail tuples when an exception occurs when the
+                     automatically fail Tuples when an exception occurs when the
                      ``process()`` method is called. Default is ``True``.
 
     **Example**:
@@ -57,7 +57,7 @@ class Bolt(Component):
 
     @staticmethod
     def is_tick(tup):
-        """ :returns: Whether or not the given Tuple is a tick tuple """
+        """ :returns: Whether or not the given Tuple is a tick Tuple """
         return tup.component == '__system' and tup.stream == '__tick'
 
     def initialize(self, storm_conf, context):
@@ -76,59 +76,59 @@ class Bolt(Component):
         pass
 
     def process(self, tup):
-        """Process a single tuple :class:`streamparse.storm.component.Tuple` of
+        """Process a single Tuple :class:`streamparse.storm.component.Tuple` of
         input
 
         This should be overridden by subclasses.
         :class:`streamparse.storm.component.Tuple` objects contain metadata
         about which component, stream and task it came from. The actual values
-        of the tuple can be accessed by calling ``tup.values``.
+        of the Tuple can be accessed by calling ``tup.values``.
 
-        :param tup: the tuple to be processed.
+        :param tup: the Tuple to be processed.
         :type tup: :class:`streamparse.storm.component.Tuple`
         """
         raise NotImplementedError()
 
     def process_tick(self, tup):
-        """Process special 'tick tuples' which allow time-based
+        """Process special 'tick Tuples' which allow time-based
         behaviour to be included in bolts.
 
         Default behaviour is to ignore time ticks.  This should be
         overridden by subclasses who wish to react to timer events
-        via tick tuples.
+        via tick Tuples.
 
-        Tick tuples will be sent to all bolts in a toplogy when the
+        Tick Tuples will be sent to all bolts in a toplogy when the
         storm configuration option 'topology.tick.tuple.freq.secs'
         is set to an integer value, the number of seconds.
 
-        :param tup: the tuple to be processed.
+        :param tup: the Tuple to be processed.
         :type tup: :class:`streamparse.storm.component.Tuple`
         """
         pass
 
     def emit(self, tup, stream=None, anchors=None, direct_task=None,
              need_task_ids=True):
-        """Emit a new tuple to a stream.
+        """Emit a new Tuple to a stream.
 
         :param tup: the Tuple payload to send to Storm, should contain only
                     JSON-serializable data.
         :type tup: :class:`list` or :class:`streamparse.storm.component.Tuple`
-        :param stream: the ID of the stream to emit this tuple to. Specify
+        :param stream: the ID of the stream to emit this Tuple to. Specify
                        ``None`` to emit to default stream.
         :type stream: str
-        :param anchors: IDs the tuples (or :class:`streamparse.storm.component.Tuple`
-                        instances) which the emitted tuples should be anchored
+        :param anchors: IDs the Tuples (or :class:`streamparse.storm.component.Tuple`
+                        instances) which the emitted Tuples should be anchored
                         to. If ``auto_anchor`` is set to ``True`` and
                         you have not specified ``anchors``, ``anchors`` will be
-                        set to the incoming/most recent tuple ID(s).
+                        set to the incoming/most recent Tuple ID(s).
         :type anchors: list
-        :param direct_task: the task to send the tuple to.
+        :param direct_task: the task to send the Tuple to.
         :type direct_task: int
         :param need_task_ids: indicate whether or not you'd like the task IDs
-                              the tuple was emitted (default: ``True``).
+                              the Tuple was emitted (default: ``True``).
         :type need_task_ids: bool
 
-        :returns: a ``list`` of task IDs that the tuple was sent to. Note that
+        :returns: a ``list`` of task IDs that the Tuple was sent to. Note that
                   when specifying direct_task, this will be equal to
                   ``[direct_task]``. If you specify ``need_task_ids=False``,
                   this function will return ``None``.
@@ -143,25 +143,25 @@ class Bolt(Component):
 
     def emit_many(self, tuples, stream=None, anchors=None, direct_task=None,
                   need_task_ids=True):
-        """Emit multiple tuples.
+        """Emit multiple Tuples.
 
-        :param tuples: a ``list`` of multiple tuple payloads to send to
-                       Storm. All tuples should contain only
+        :param tuples: a ``list`` of multiple Tuple payloads to send to
+                       Storm. All Tuples should contain only
                        JSON-serializable data.
         :type tuples: list
-        :param stream: the ID of the steram to emit these tuples to. Specify
+        :param stream: the ID of the steram to emit these Tuples to. Specify
                        ``None`` to emit to default stream.
         :type stream: str
-        :param anchors: IDs the tuples (or :class:`streamparse.storm.component.Tuple`
-                        instances) which the emitted tuples should be anchored
+        :param anchors: IDs the Tuples (or :class:`streamparse.storm.component.Tuple`
+                        instances) which the emitted Tuples should be anchored
                         to. If ``auto_anchor`` is set to ``True`` and
                         you have not specified ``anchors``, ``anchors`` will be
-                        set to the incoming/most recent tuple ID(s).
+                        set to the incoming/most recent Tuple ID(s).
         :type anchors: list
-        :param direct_task: indicates the task to send the tuple to.
+        :param direct_task: indicates the task to send the Tuple to.
         :type direct_task: int
         :param need_task_ids: indicate whether or not you'd like the task IDs
-                              the tuple was emitted (default:
+                              the Tuple was emitted (default:
                               ``True``).
         :type need_task_ids: bool
 
@@ -169,7 +169,7 @@ class Bolt(Component):
             Just call :py:meth:`Bolt.emit` repeatedly instead.
         """
         if not isinstance(tuples, (list, tuple)):
-            raise TypeError('tuples should be a list of lists/tuples, '
+            raise TypeError('Tuples should be a list of lists/tuples, '
                             'received {!r} instead.'.format(type(tuples)))
 
         all_task_ids = []
@@ -181,18 +181,18 @@ class Bolt(Component):
         return all_task_ids
 
     def ack(self, tup):
-        """Indicate that processing of a tuple has succeeded.
+        """Indicate that processing of a Tuple has succeeded.
 
-        :param tup: the tuple to acknowledge.
+        :param tup: the Tuple to acknowledge.
         :type tup: :class:`str` or :class:`streamparse.storm.component.Tuple`
         """
         tup_id = tup.id if isinstance(tup, Tuple) else tup
         self.send_message({'command': 'ack', 'id': tup_id})
 
     def fail(self, tup):
-        """Indicate that processing of a tuple has failed.
+        """Indicate that processing of a Tuple has failed.
 
-        :param tup: the tuple to fail (its ``id`` if ``str``).
+        :param tup: the Tuple to fail (its ``id`` if ``str``).
         :type tup: :class:`str` or :class:`streamparse.storm.component.Tuple`
         """
         tup_id = tup.id if isinstance(tup, Tuple) else tup
@@ -215,7 +215,7 @@ class Bolt(Component):
             self.process(tup)
             if self.auto_ack:
                  self.ack(tup)
-        # reset so that we don't accidentally fail the wrong tuples
+        # reset so that we don't accidentally fail the wrong Tuples
         # if a successive call to read_tuple fails
         self._current_tups = []
 
@@ -233,19 +233,19 @@ class Bolt(Component):
                 self.fail(tup)
 
 class BatchingBolt(Bolt):
-    """A bolt which batches tuples for processing.
+    """A bolt which batches Tuples for processing.
 
-    Batching tuples is unexpectedly complex to do correctly. The main problem
+    Batching Tuples is unexpectedly complex to do correctly. The main problem
     is that all bolts are single-threaded. The difficult comes when the
-    topology is shutting down because Storm stops feeding the bolt tuples. If
+    topology is shutting down because Storm stops feeding the bolt Tuples. If
     the bolt is blocked waiting on stdin, then it can't process any waiting
-    tuples, or even ack ones that were asynchronously written to a data store.
+    Tuples, or even ack ones that were asynchronously written to a data store.
 
-    This bolt helps with that by grouping tuples received between tick tuples
+    This bolt helps with that by grouping Tuples received between tick Tuples
     into batches.
 
     To use this class, you must implement ``process_batch``. ``group_key`` can
-    be optionally implemented so that tuples are grouped before
+    be optionally implemented so that Tuples are grouped before
     ``process_batch`` is even called.
 
     You must also set the `topology.tick.tuple.freq.secs` to how frequently you
@@ -258,18 +258,18 @@ class BatchingBolt(Bolt):
 
 
     :ivar auto_anchor: A ``bool`` indicating whether or not the bolt should
-                       automatically anchor emits to the incoming tuple ID.
+                       automatically anchor emits to the incoming Tuple ID.
                        Tuple anchoring is how Storm provides reliability, you
-                       can read more about `tuple anchoring in Storm's
+                       can read more about `Tuple anchoring in Storm's
                        docs <https://storm.incubator.apache.org/documentation/Guaranteeing-message-processing.html#what-is-storms-reliability-api>`_.
                        Default is ``True``.
     :ivar auto_ack: A ``bool`` indicating whether or not the bolt should
-                    automatically acknowledge tuples after ``process_batch()``
+                    automatically acknowledge Tuples after ``process_batch()``
                     is called. Default is ``True``.
     :ivar auto_fail: A ``bool`` indicating whether or not the bolt should
-                     automatically fail tuples when an exception occurs when the
+                     automatically fail Tuples when an exception occurs when the
                      ``process_batch()`` method is called. Default is ``True``.
-    :ivar ticks_between_batches: The number of tick tuples to wait before
+    :ivar ticks_between_batches: The number of tick Tuples to wait before
                                  processing a batch.
 
 
@@ -303,20 +303,20 @@ class BatchingBolt(Bolt):
         self._tick_counter = 0
 
     def group_key(self, tup):
-        """Return the group key used to group tuples within a batch.
+        """Return the group key used to group Tuples within a batch.
 
-        By default, returns None, which put all tuples in a single
+        By default, returns None, which put all Tuples in a single
         batch, effectively just time-based batching. Override this to create
         multiple batches based on a key.
 
-        :param tup: the tuple used to extract a group key
+        :param tup: the Tuple used to extract a group key
         :type tup: :class:`streamparse.storm.component.Tuple`
         :returns: Any ``hashable`` value.
         """
         return None
 
     def process_batch(self, key, tups):
-        """Process a batch of tuples. Should be overridden by subclasses.
+        """Process a batch of Tuples. Should be overridden by subclasses.
 
         :param key: the group key for the list of batches.
         :type key: hashable
@@ -358,10 +358,10 @@ class BatchingBolt(Bolt):
 
         .. warning::
             This method should **not** be overriden.  If you want to tweak
-            how tuples are grouped into batches, override ``group_key``.
+            how Tuples are grouped into batches, override ``group_key``.
         """
         self._tick_counter += 1
-        # ACK tick tuple immediately, since it's just responsible for counter
+        # ACK tick Tuple immediately, since it's just responsible for counter
         self.ack(tick_tup)
         if self._tick_counter > self.ticks_between_batches and self._batches:
             for key, batch in iteritems(self._batches):
@@ -377,13 +377,13 @@ class BatchingBolt(Bolt):
             self._tick_counter = 0
 
     def process(self, tup):
-        """Group non-tick tuples into batches by ``group_key``.
+        """Group non-tick Tuples into batches by ``group_key``.
 
         .. warning::
             This method should **not** be overriden.  If you want to tweak
-            how tuples are grouped into batches, override ``group_key``.
+            how Tuples are grouped into batches, override ``group_key``.
         """
-        # Append latest tuple to batches
+        # Append latest Tuple to batches
         group_key = self.group_key(tup)
         self._batches[group_key].append(tup)
 
@@ -400,7 +400,7 @@ class BatchingBolt(Bolt):
             self.process_tick(tup)
         else:
             self.process(tup)
-        # reset so that we don't accidentally fail the wrong tuples
+        # reset so that we don't accidentally fail the wrong Tuples
         # if a successive call to read_tuple fails
         self._current_tups = []
 
@@ -418,7 +418,7 @@ class BatchingBolt(Bolt):
             for batch in itervalues(self._batches):
                 for tup in batch:
                     self.fail(tup)
-            # Fail current tick tuple if we have one
+            # Fail current tick Tuple if we have one
             for tup in self._current_tups:
                 if self.is_tick(tup):
                     self.fail(tup)

--- a/streamparse/storm/bolt.py
+++ b/streamparse/storm/bolt.py
@@ -18,13 +18,13 @@ class Bolt(Component):
     """The base class for all streamparse bolts.
 
     For more information on bolts, consult Storm's
-    `Concepts documentation <http://storm.incubator.apache.org/documentation/Concepts.html>`_.
+    `Concepts documentation <http://storm.apache.org/documentation/Concepts.html>`_.
 
     :ivar auto_anchor: A ``bool`` indicating whether or not the bolt should
                        automatically anchor emits to the incoming Tuple ID.
                        Tuple anchoring is how Storm provides reliability, you
                        can read more about
-                       `Tuple anchoring in Storm's docs <https://storm.incubator.apache.org/documentation/Guaranteeing-message-processing.html#what-is-storms-reliability-api>`_.
+                       `Tuple anchoring in Storm's docs <https://storm.apache.org/documentation/Guaranteeing-message-processing.html#what-is-storms-reliability-api>`_.
                        Default is ``True``.
 
     :ivar auto_ack: A ``bool`` indicating whether or not the bolt should
@@ -261,7 +261,7 @@ class BatchingBolt(Bolt):
                        automatically anchor emits to the incoming Tuple ID.
                        Tuple anchoring is how Storm provides reliability, you
                        can read more about `Tuple anchoring in Storm's
-                       docs <https://storm.incubator.apache.org/documentation/Guaranteeing-message-processing.html#what-is-storms-reliability-api>`_.
+                       docs <https://storm.apache.org/documentation/Guaranteeing-message-processing.html#what-is-storms-reliability-api>`_.
                        Default is ``True``.
     :ivar auto_ack: A ``bool`` indicating whether or not the bolt should
                     automatically acknowledge Tuples after ``process_batch()``

--- a/streamparse/storm/bolt.py
+++ b/streamparse/storm/bolt.py
@@ -1,4 +1,4 @@
-"""Base Bolt classes."""
+"""Base bolt classes."""
 from __future__ import absolute_import, print_function, unicode_literals
 
 import logging
@@ -52,7 +52,7 @@ class Bolt(Component):
     auto_ack = True
     auto_fail = True
 
-    # Using a list so Bolt and subclasses can have more than one current_tup
+    # Using list; Bolt class and subclasses can have more than one current_tup.
     _current_tups = []
 
     @staticmethod
@@ -65,7 +65,7 @@ class Bolt(Component):
         the main run loop. A good place to initialize connections to data
         sources.
 
-        :param storm_conf: the Storm configuration for this Bolt.  This is the
+        :param storm_conf: the Storm configuration for this bolt.  This is the
                            configuration provided to the topology, merged in
                            with cluster configuration on the worker node.
         :type storm_conf: dict
@@ -409,7 +409,7 @@ class BatchingBolt(Bolt):
 
         Called right before program exits.
         """
-        # Don't use super here, because Bolt does its own auto fail handling.
+        # Don't use super here, because Bolt class has own auto fail handling.
         Component._handle_run_exception(self, exc)
         self.raise_exception(exc, self._current_tups)
 

--- a/streamparse/storm/component.py
+++ b/streamparse/storm/component.py
@@ -129,7 +129,7 @@ Tuple = namedtuple('Tuple', 'id component stream task values')
 
 
 class Component(object):
-    """Base class for Spouts and Bolts which contains class methods for
+    """Base class for spouts and bolts which contains class methods for
     logging messages back to the Storm worker process.
 
 
@@ -267,7 +267,7 @@ class Component(object):
     def read_message(self):
         """Read a message from Storm, reconstruct newlines appropriately.
 
-        All of Storm's messages (for either Bolts or Spouts) should be of the
+        All of Storm's messages (for either bolts or spouts) should be of the
         form::
 
             '<command or task_id form prior emit>\\nend\\n'
@@ -276,7 +276,7 @@ class Component(object):
 
             '{ "id": "-6955786537413359385",  "comp": "1", "stream": "1", "task": 9, "tuple": ["snow white and the seven dwarfs", "field2", 3]}\\nend\\n'
 
-        Command example for a Spout to emit it's next tuple::
+        Command example for a spout to emit it's next tuple::
 
             '{"command": "next"}\\nend\\n'
 
@@ -499,4 +499,3 @@ class Component(object):
         log_msg = "Exception in {}.run()".format(self.__class__.__name__)
         log.error(log_msg, exc_info=True)
         self.raise_exception(exc)
-

--- a/streamparse/storm/component.py
+++ b/streamparse/storm/component.py
@@ -115,15 +115,15 @@ class LogStream(object):
 Tuple = namedtuple('Tuple', 'id component stream task values')
 """Storm's primitive data type passed around via streams.
 
-:ivar id: the ID of the tuple.
+:ivar id: the ID of the Tuple.
 :type id: str
-:ivar component: component that the tuple was generated from.
+:ivar component: component that the Tuple was generated from.
 :type component: str
-:ivar stream: the stream that the tuple was emitted into.
+:ivar stream: the stream that the Tuple was emitted into.
 :type stream: str
-:ivar task: the task the tuple was generated from.
+:ivar task: the task the Tuple was generated from.
 :type task: int
-:ivar values: the payload of the tuple where data is stored.
+:ivar values: the payload of the Tuple where data is stored.
 :type values: list
 """
 
@@ -182,9 +182,9 @@ class Component(object):
         self.context = None
         self.pid = os.getpid()
         self.logger = None
-        # pending commands/tuples we read while trying to read task IDs
+        # pending commands/Tuples we read while trying to read task IDs
         self._pending_commands = deque()
-        # pending task IDs we read while trying to read commands/tuples
+        # pending task IDs we read while trying to read commands/Tuples
         self._pending_task_ids = deque()
         self._reader_lock = RLock()
         self._writer_lock = RLock()
@@ -272,11 +272,11 @@ class Component(object):
 
             '<command or task_id form prior emit>\\nend\\n'
 
-        Command example, an incoming tuple to a bolt::
+        Command example, an incoming Tuple to a bolt::
 
             '{ "id": "-6955786537413359385",  "comp": "1", "stream": "1", "task": 9, "tuple": ["snow white and the seven dwarfs", "field2", 3]}\\nend\\n'
 
-        Command example for a spout to emit it's next tuple::
+        Command example for a spout to emit its next Tuple::
 
             '{"command": "next"}\\nend\\n'
 
@@ -374,7 +374,7 @@ class Component(object):
         :param tup: a :class:`Tuple` object.
         """
         if tup:
-            message = ('Python {exception_name} raised while processing tuple '
+            message = ('Python {exception_name} raised while processing Tuple '
                        '{tup!r}\n{traceback}')
         else:
             message = 'Python {exception_name} raised\n{traceback}'
@@ -409,36 +409,36 @@ class Component(object):
 
     def emit(self, tup, tup_id=None, stream=None, anchors=None,
              direct_task=None, need_task_ids=True):
-        """Emit a new tuple to a stream.
+        """Emit a new Tuple to a stream.
 
         :param tup: the Tuple payload to send to Storm, should contain only
                     JSON-serializable data.
         :type tup: :class:`list` or :class:`streamparse.storm.component.Tuple`
-        :param tup_id: the ID for the tuple. If omitted by a
+        :param tup_id: the ID for the Tuple. If omitted by a
                        :class:`streamparse.storm.spout.Spout`, this emit will be
                        unreliable.
         :type tup_id: str
-        :param stream: the ID of the stream to emit this tuple to. Specify
+        :param stream: the ID of the stream to emit this Tuple to. Specify
                        ``None`` to emit to default stream.
         :type stream: str
-        :param anchors: IDs the tuples (or
+        :param anchors: IDs the Tuples (or
                         :class:`streamparse.storm.component.Tuple` instances)
-                        which the emitted tuples should be anchored to. This is
+                        which the emitted Tuples should be anchored to. This is
                         only passed by :class:`streamparse.storm.bolt.Bolt`.
         :type anchors: list
-        :param direct_task: the task to send the tuple to.
+        :param direct_task: the task to send the Tuple to.
         :type direct_task: int
         :param need_task_ids: indicate whether or not you'd like the task IDs
-                              the tuple was emitted (default: ``True``).
+                              the Tuple was emitted (default: ``True``).
         :type need_task_ids: bool
 
-        :returns: a ``list`` of task IDs that the tuple was sent to. Note that
+        :returns: a ``list`` of task IDs that the Tuple was sent to. Note that
                   when specifying direct_task, this will be equal to
                   ``[direct_task]``. If you specify ``need_task_ids=False``,
                   this function will return ``None``.
         """
         if not isinstance(tup, (list, tuple)):
-            raise TypeError('All tuples must be either lists or tuples, '
+            raise TypeError('All Tuples must be either lists or tuples, '
                             'received {!r} instead.'.format(type(tup)))
 
         msg = {'command': 'emit', 'tuple': tup}
@@ -472,7 +472,7 @@ class Component(object):
     def run(self):
         """Main run loop for all components.
 
-        Performs initial handshake with Storm and reads tuples handing them off
+        Performs initial handshake with Storm and reads Tuples handing them off
         to subclasses.  Any exceptions are caught and logged back to Storm
         prior to the Python process exiting.
 

--- a/streamparse/storm/spout.py
+++ b/streamparse/storm/spout.py
@@ -27,7 +27,7 @@ class Spout(Component):
         the main run loop. A good place to initialize connections to data
         sources.
 
-        :param storm_conf: the Storm configuration for this Spout.  This is the
+        :param storm_conf: the Storm configuration for this spout. This is the
                            configuration provided to the topology, merged in
                            with cluster configuration on the worker node.
         :type storm_conf: dict
@@ -49,7 +49,7 @@ class Spout(Component):
     def fail(self, tup_id):
         """Called when a tuple fails in the topology
 
-        A Spout can choose to emit the tuple again or ignore the fail. The
+        A spout can choose to emit the tuple again or ignore the fail. The
         default is to ignore.
 
         :param tup_id: the ID of the tuple that has failed in the topology

--- a/streamparse/storm/spout.py
+++ b/streamparse/storm/spout.py
@@ -38,29 +38,29 @@ class Spout(Component):
         pass
 
     def ack(self, tup_id):
-        """Called when a bolt acknowledges a tuple in the topology.
+        """Called when a bolt acknowledges a Tuple in the topology.
 
-        :param tup_id: the ID of the tuple that has been fully acknowledged in
+        :param tup_id: the ID of the Tuple that has been fully acknowledged in
                        the topology.
         :type tup_id: str
         """
         pass
 
     def fail(self, tup_id):
-        """Called when a tuple fails in the topology
+        """Called when a Tuple fails in the topology
 
-        A spout can choose to emit the tuple again or ignore the fail. The
+        A spout can choose to emit the Tuple again or ignore the fail. The
         default is to ignore.
 
-        :param tup_id: the ID of the tuple that has failed in the topology
-                       either due to a bolt calling ``fail()`` or a tuple
+        :param tup_id: the ID of the Tuple that has failed in the topology
+                       either due to a bolt calling ``fail()`` or a Tuple
                        timing out.
         :type tup_id: str
         """
         pass
 
     def next_tuple(self):
-        """Implement this function to emit tuples as necessary.
+        """Implement this function to emit Tuples as necessary.
 
         This function should not block, or Storm will think the
         spout is dead. Instead, let it return and streamparse will
@@ -70,26 +70,26 @@ class Spout(Component):
 
     def emit(self, tup, tup_id=None, stream=None, direct_task=None,
              need_task_ids=True):
-        """Emit a spout tuple message.
+        """Emit a spout Tuple message.
 
-        :param tup: the tuple to send to Storm, should contain only
+        :param tup: the Tuple to send to Storm, should contain only
                     JSON-serializable data.
         :type tup: list or tuple
-        :param tup_id: the ID for the tuple. Leave this blank for an
+        :param tup_id: the ID for the Tuple. Leave this blank for an
                        unreliable emit.
         :type tup_id: str
-        :param stream: ID of the stream this tuple should be emitted to.
+        :param stream: ID of the stream this Tuple should be emitted to.
                        Leave empty to emit to the default stream.
         :type stream: str
-        :param direct_task: the task to send the tuple to if performing a
+        :param direct_task: the task to send the Tuple to if performing a
                             direct emit.
         :type direct_task: int
         :param need_task_ids: indicate whether or not you'd like the task IDs
-                              the tuple was emitted (default:
+                              the Tuple was emitted (default:
                               ``True``).
         :type need_task_ids: bool
 
-        :returns: a ``list`` of task IDs that the tuple was sent to. Note that
+        :returns: a ``list`` of task IDs that the Tuple was sent to. Note that
                   when specifying direct_task, this will be equal to
                   ``[direct_task]``. If you specify ``need_task_ids=False``,
                   this function will return ``None``.
@@ -102,23 +102,23 @@ class Spout(Component):
                   need_task_ids=True):
         """Emit multiple tuples.
 
-        :param tuples: a ``list`` of multiple tuple payloads to send to
-                       Storm. All tuples should contain only
+        :param tuples: a ``list`` of multiple Tuple payloads to send to
+                       Storm. All Tuples should contain only
                        JSON-serializable data.
         :type tuples: list
-        :param stream: the ID of the steram to emit these tuples to. Specify
+        :param stream: the ID of the stream to emit these Tuples to. Specify
                        ``None`` to emit to default stream.
         :type stream: str
-        :param tup_ids: the ID for the tuple. Leave this blank for an
+        :param tup_ids: the ID for the Tuple. Leave this blank for an
                        unreliable emit.
         :type tup_ids: list
-        :param tup_ids: IDs for each of the tuples in the list.  Omit these for
+        :param tup_ids: IDs for each of the Tuples in the list.  Omit these for
                         an unreliable emit.
         :type anchors: list
-        :param direct_task: indicates the task to send the tuple to.
+        :param direct_task: indicates the task to send the Tuple to.
         :type direct_task: int
         :param need_task_ids: indicate whether or not you'd like the task IDs
-                              the tuple was emitted (default:
+                              the Tuple was emitted (default:
                               ``True``).
         :type need_task_ids: bool
 
@@ -126,7 +126,7 @@ class Spout(Component):
             Just call :py:meth:`Spout.emit` repeatedly instead.
         """
         if not isinstance(tuples, (list, tuple)):
-            raise TypeError('tuples should be a list of lists/tuples, '
+            raise TypeError('Tuples should be a list of lists/tuples, '
                             'received {!r} instead.'.format(type(tuples)))
 
         all_task_ids = []

--- a/streamparse/storm/spout.py
+++ b/streamparse/storm/spout.py
@@ -19,7 +19,7 @@ class Spout(Component):
     """Base class for all streamparse spouts.
 
     For more information on spouts, consult Storm's
-    `Concepts documentation <http://storm.incubator.apache.org/documentation/Concepts.html>`_.
+    `Concepts documentation <http://storm.apache.org/documentation/Concepts.html>`_.
     """
 
     def initialize(self, storm_conf, context):

--- a/test/streamparse/test_bolt.py
+++ b/test/streamparse/test_bolt.py
@@ -297,7 +297,7 @@ class BatchingBoltTests(unittest.TestCase):
 
     @patch.object(BatchingBolt, 'process_batch', autospec=True)
     def test_batching(self, process_batch_mock):
-        # Add a bunch of tuples
+        # Add a bunch of Tuples
         for __ in self.tups:
             self.bolt._run()
 
@@ -309,7 +309,7 @@ class BatchingBoltTests(unittest.TestCase):
         # Change the group key to even/odd grouping
         self.bolt.group_key = lambda t: sum(t.values) % 2
 
-        # Add a bunch of tuples
+        # Add a bunch of Tuples
         for __ in self.tups:
             self.bolt._run()
 
@@ -357,7 +357,7 @@ class BatchingBoltTests(unittest.TestCase):
         # Test auto-fail on (the default)
         self.bolt.run()
 
-        # All waiting tuples should have failed at this point
+        # All waiting Tuples should have failed at this point
         fail_mock.assert_has_calls([mock.call(self.bolt, self.nontick_tups[0]),
                                     mock.call(self.bolt, self.nontick_tups[1]),
                                     mock.call(self.bolt, self.nontick_tups[2])],
@@ -377,7 +377,7 @@ class BatchingBoltTests(unittest.TestCase):
         self.bolt.auto_fail = False
         self.bolt.run()
 
-        # All waiting tuples should have failed at this point
+        # All waiting Tuples should have failed at this point
         self.assertEqual(exit_mock.call_count, 1)
         self.assertListEqual(fail_mock.call_args_list, [])
 
@@ -402,8 +402,8 @@ class BatchingBoltTests(unittest.TestCase):
         process_batch_mock.side_effect = work_once
         # Run the batches
         self.bolt.run()
-        # Only some tuples should have failed at this point. The key is that
-        # all un-acked tuples should be failed, even for batches we haven't
+        # Only some Tuples should have failed at this point. The key is that
+        # all un-acked Tuples should be failed, even for batches we haven't
         # started processing yet.
         self.assertEqual(fail_mock.call_count, 2)
         self.assertEqual(exit_mock.call_count, 1)

--- a/test/streamparse/test_component.py
+++ b/test/streamparse/test_component.py
@@ -135,7 +135,7 @@ class ComponentTests(unittest.TestCase):
     def test_read_message(self):
         inputs = [# Task IDs
                   '[12, 22, 24]\n', 'end\n',
-                  # Incoming tuple for bolt
+                  # Incoming Tuple for bolt
                   ('{ "id": "-6955786537413359385", "comp": "1", "stream": "1"'
                    ', "task": 9, "tuple": ["snow white and the seven dwarfs", '
                    '"field2", 3]}\n'), 'end\n',
@@ -159,7 +159,7 @@ class ComponentTests(unittest.TestCase):
     def test_read_message_unicode(self):
         inputs = [# Task IDs
                   '[12, 22, 24]\n', 'end\n',
-                  # Incoming tuple for bolt
+                  # Incoming Tuple for bolt
                   ('{ "id": "-6955786537413359385", "comp": "1", "stream": "1"'
                    ', "task": 9, "tuple": ["snow white \uFFE6 the seven dwarfs"'
                    ', "field2", 3]}\n'), 'end\n',
@@ -199,7 +199,7 @@ class ComponentTests(unittest.TestCase):
         # Check that we properly queue task IDs and return only commands
         inputs = [# Task IDs
                   '[12, 22, 24]\n', 'end\n',
-                  # Incoming tuple for bolt
+                  # Incoming Tuple for bolt
                   ('{ "id": "-6955786537413359385", "comp": "1", "stream": "1"'
                    ', "task": 9, "tuple": ["snow white and the seven dwarfs", '
                    '"field2", 3]}\n'), 'end\n',
@@ -221,7 +221,7 @@ class ComponentTests(unittest.TestCase):
         # Check that we properly queue commands and return only task IDs
         inputs = [# Task IDs
                   '[4, 8, 15]\n', 'end\n',
-                  # Incoming tuple for bolt
+                  # Incoming Tuple for bolt
                   ('{ "id": "-6955786537413359385", "comp": "1", "stream": "1"'
                    ', "task": 9, "tuple": ["snow white and the seven dwarfs", '
                    '"field2", 3]}\n'), 'end\n',
@@ -244,15 +244,15 @@ class ComponentTests(unittest.TestCase):
 
     def test_read_tuple(self):
         # This is only valid for bolts, so we only need to test with task IDs
-        # and tuples
+        # and Tuples
         inputs = [# Tuple with all values
                   ('{ "id": "-6955786537413359385", "comp": "1", "stream": "1"'
                    ', "task": 9, "tuple": ["snow white and the seven dwarfs", '
                    '"field2", 3]}\n'), 'end\n',
-                  # Tick tuple
+                  # Tick Tuple
                   ('{ "id": null, "task": -1, "comp": "__system", "stream": '
                    '"__tick", "tuple": [50]}\n'), 'end\n',
-                  # Heartbeat tuple
+                  # Heartbeat Tuple
                   ('{ "id": null, "task": -1, "comp": "__system", "stream": '
                    '"__heartbeat", "tuple": []}\n'), 'end\n',
                   ]
@@ -269,7 +269,7 @@ class ComponentTests(unittest.TestCase):
                               output_stream=BytesIO())
 
         for output in outputs:
-            log.info('Checking tuple for %s', output)
+            log.info('Checking Tuple for %s', output)
             tup = component.read_tuple()
             self.assertEqual(output, tup)
 


### PR DESCRIPTION
Fix #164. This may seem trivial, but consistency will help contribution. The Tuple/tuple distinction is where we may not agree. I went with capitalization of Tuple in the source (narrative docs use lowercase consistently) as to disambiguate from Python tuples.