### PR TITLE
Add back old batching bolt with timer threads as TicklessBatchingBolt.

### DIFF
--- a/streamparse/storm/bolt.py
+++ b/streamparse/storm/bolt.py
@@ -237,6 +237,7 @@ class Bolt(Component):
             if self.auto_fail:
                 self.fail(tup)
 
+
 class BatchingBolt(Bolt):
     """A bolt which batches Tuples for processing.
 


### PR DESCRIPTION
I haven't pushed 2.1.0 to PyPI yet, and I was hoping to squeeze this in before I did.