### PR TITLE
Docs: fix outdated :use in quickstart

### DIFF
--- a/doc/source/quickstart.rst
+++ b/doc/source/quickstart.rst
@@ -142,7 +142,7 @@ though these are not strictly required.
 .. code-block:: clojure
 
     (ns wordcount
-      (:use     [backtype.storm.clojure])
+      (:use     [streamparse.specs])
       (:gen-class))
 
 The next block of code actually defines the topology and stores it into a


### PR DESCRIPTION
In commit 72f5a8821dad, `backtype.storm.clojure` was changed to `streamparse.specs` in the `wordcount.clj` code block, but not the smaller snippet right below.