### PR TITLE
Pin pystorm version to >= 2.0.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,5 @@ requests
 prettytable
 setuptools
 simplejson
-pystorm
+pystorm>=2.0.1
 thriftpy>=0.3.2

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ install_requires = [
     'prettytable',
     'six>=1.5',
     'simplejson',
-    'pystorm',
+    'pystorm>=2.0.1',
     'thriftpy>=0.3.2'
 ]
 

--- a/streamparse/version.py
+++ b/streamparse/version.py
@@ -29,5 +29,5 @@ def _safe_int(string):
         return string
 
 
-__version__ = '3.0.0.dev1'
+__version__ = '3.0.0.dev2'
 VERSION = tuple(_safe_int(x) for x in __version__.split('.'))


### PR DESCRIPTION
This way users get bugfixes included in newer versions of pystorm and we can mention them in our release notes.