### PR TITLE
Added support for custom filenames for logging and updated quickstart docs.

### DIFF
--- a/doc/source/quickstart.rst
+++ b/doc/source/quickstart.rst
@@ -321,6 +321,7 @@ in our ``config.json`` file:
                 ],
                 "log": {
                     "path": "/var/log/storm/streamparse",
+                    "file": "pystorm_{topology_name}_{component_name}_{task_id}_{pid}.log",
                     "max_bytes": 100000,
                     "backup_count": 10,
                     "level": "info"
@@ -398,17 +399,18 @@ Logging
 The Storm supervisor needs to have access to the ``log.path`` directory for
 logging to work (in the example above, ``/var/log/storm/streamparse``). If you
 have properly configured the ``log.path`` option in your config, streamparse
-will automatically set up a log files on each Storm worker in this path using
-the following filename convention::
+will use the value for the ``log.file`` option to set up log files for each
+Storm worker in this path. The filename can be customized further by using
+certain named placeholders. The default filename is set to::
 
-    streamparse_<topology_name>_<component_name>_<task_id>_<process_id>.log
+    pystorm_{topology_name}_{component_name}_{task_id}_{pid}.log
 
 Where:
 
 * ``topology_name``: is the ``topology.name`` variable set in Storm
 * ``component_name``: is the name of the currently executing component as defined in your topology definition file (.clj file)
 * ``task_id``: is the task ID running this component in the topology
-* ``process_id``: is the process ID of the Python process
+* ``pid``: is the process ID of the Python process
 
 streamparse uses Python's ``logging.handlers.RotatingFileHandler`` and by
 default will only save 10 1 MB log files (10 MB in total), but this can be

--- a/streamparse/cli/submit.py
+++ b/streamparse/cli/submit.py
@@ -103,10 +103,13 @@ def _submit_topology(topology_name, topology_class, uploaded_jar, env_config,
     # Python logging settings
     log_config = env_config.get("log", {})
     log_path = log_config.get("path") or env_config.get("log_path")
+    log_file = log_config.get("file") or env_config.get("log_file")
     print("Routing Python logging to {}.".format(log_path))
     sys.stdout.flush()
     if log_path:
         storm_options['pystorm.log.path'] = log_path
+    if log_file:
+        storm_options['pystorm.log.file'] = log_file
     if isinstance(log_config.get("max_bytes"), int):
         storm_options['pystorm.log.max_bytes'] = log_config["max_bytes"]
     if isinstance(log_config.get("backup_count"), int):


### PR DESCRIPTION
This commit adds support for custom log filenames as added to pystorm in the following PR:
https://github.com/pystorm/pystorm/pull/25

I'm pretty sure this isn't as complete as it could/should be, since the `tail` cli functionality currently relies on hardcoded filename patterns for matching.