### PR TITLE
Add config options processing for FLUX YAML DSL

### DIFF
--- a/streamparse/dsl/topology.py
+++ b/streamparse/dsl/topology.py
@@ -203,6 +203,18 @@ class Topology(object):
                 raise TypeError('Flux does not currently support ShellBolts '
                                 'with multiple streams. Given: {!r}'
                                 .format(spec))
+            
+            flux_dict['configMethods'] = []
+            if spec.config:
+                import json
+                dconf = spec.config
+                if not isinstance(spec.config, dict):
+                    dconf = json.loads(spec.config)
+                for key, value in dconf.iteritems():
+                    flux_dict['configMethods'].append({
+                        'name': 'addComponentConfig',
+                        "args": [key, value]
+                    })
         else:
             if spec.component_object.serialized_java is not None:
                 raise TypeError('Flux does not support specifying serialized '


### PR DESCRIPTION
Configs are now passed via YAML to FluxShellBolt/Spout.

Need to wait for upstream PUSH. 
So far I've created only the issue, since there is a little bug.
https://issues.apache.org/jira/browse/STORM-1870
