### PR TITLE
Find worker logs in worker-artifacts subdirectory

### DIFF
--- a/streamparse/util.py
+++ b/streamparse/util.py
@@ -365,9 +365,9 @@ def _get_file_names_command(path, patterns):
     """Given a list of bash `find` patterns, return a string for the
     bash command that will find those pystorm log files
     """
-    patterns = "' -o -name '".join(patterns)
+    patterns = "' -o -type f -name '".join(patterns)
     return ("cd {path} && "
-            "find . -maxdepth 1 -name '{patterns}' ") \
+            "find . -maxdepth 4 -type f -name '{patterns}'") \
             .format(path=path, patterns=patterns)
 
 


### PR DESCRIPTION
[STORM-901](https://issues.apache.org/jira/browse/STORM-901) moves worker log files into subdirectories which `sparse tail` doesn't find. This is an attempt to resolve that.

Closes #268, I think.