### PR TITLE
upload jar before killing existing topology

### DIFF
--- a/streamparse/cli/submit.py
+++ b/streamparse/cli/submit.py
@@ -230,8 +230,8 @@ def submit_topology(name=None, env_name="prod", workers=None, ackers=None,
     # Use ssh tunnel with Nimbus if use_ssh_for_nimbus is unspecified or True
     with ssh_tunnel(env_config) as (host, port):
         nimbus_client = get_nimbus_client(env_config, host=host, port=port)
-        _kill_existing_topology(name, force, wait, nimbus_client)
         uploaded_jar = _upload_jar(nimbus_client, topology_jar)
+        _kill_existing_topology(name, force, wait, nimbus_client)
         _submit_topology(name, topology_class, uploaded_jar, config, env_config,
                          workers, ackers, nimbus_client, options=options,
                          debug=debug)


### PR DESCRIPTION
if we kill the topology before uploading the jar, the topology stays disabled until the upload is complete. on a slow network, this can lead to the topology being disabled for an unacceptably long time during the deployment. additionally, if the upload fails and deployment crashes, this change will ensure that it did not have a destructive effect on the existing topology.