### PR TITLE
Default to number of storm worker nodes instead of 2 for ackers/workers

### DIFF
--- a/streamparse/cli/common.py
+++ b/streamparse/cli/common.py
@@ -95,11 +95,11 @@ def add_override_name(parser):
 def add_par(parser):
     """ Add --par option to parser """
     parser.add_argument('-p', '--par',
-                        default=2,
                         type=int,
                         help='Parallelism of topology; conveniently sets '
                              'number of Storm workers and acker bolts at once '
-                             'to passed value. (default: %(default)s)')
+                             'to passed value. Defaults to the number of worker'
+                             ' nodes in your Storm environment.')
 
 def add_pattern(parser):
     """ Add --pattern option to parser """

--- a/streamparse/cli/run.py
+++ b/streamparse/cli/run.py
@@ -16,9 +16,13 @@ from .common import (add_ackers, add_debug, add_environment, add_name,
 from .jar import jar_for_deploy
 
 
-def run_local_topology(name=None, time=0, workers=2, ackers=2, options=None,
-                       debug=False):
+def run_local_topology(name=None, time=0, workers=None, ackers=None,
+                       options=None, debug=False):
     """Run a topology locally using Flux and `storm jar`."""
+    if workers is None:
+        workers = 1
+    if ackers is None:
+        ackers = 1
     storm_options = {'topology.workers': workers,
                      'topology.acker.executors': ackers,
                      'topology.debug': debug}

--- a/streamparse/cli/submit.py
+++ b/streamparse/cli/submit.py
@@ -215,10 +215,10 @@ def submit_topology(name=None, env_name="prod", workers=None, ackers=None,
         additional_options.update(options)
     options = additional_options
 
-    if not workers:
-        workers = env_config.get('worker_count', 2)
-    if not ackers:
-        ackers = env_config.get('acker_count', 2)
+    if workers is None:
+        workers = env_config.get('worker_count', len(env.storm_workers))
+    if ackers is None:
+        ackers = env_config.get('acker_count', len(env.storm_workers))
 
     # Check topology for JVM stuff to see if we need to create uber-jar
     if simple_jar:


### PR DESCRIPTION
This means we default to the number of nodes in `config.json` for `sparse submit` and 1 for `sparse run` (since it's only running on a single machine).

This also fixes an issue where 0 would be overwritten when someone passed it for `--ackers` or `--workers`.