### PR TITLE
Refactor how we handle options at topology, environment, and CLI levels.

### DIFF
--- a/streamparse/dsl/topology.py
+++ b/streamparse/dsl/topology.py
@@ -39,7 +39,12 @@ class TopologyType(type):
         if classname != 'Topology' and not spout_specs:
             raise ValueError('A Topology requires at least one Spout')
         if 'config' in class_dict:
-            TopologyType.propogate_config(class_dict['config'], specs)
+            config_dict = class_dict['config']
+            if not isinstance(config_dict, dict):
+                raise TypeError('Topology config must be a dictionary. Given: '
+                                '{!r}'.format(config_dict))
+        else:
+            class_dict['config'] = {}
         class_dict['thrift_bolts'] = bolt_specs
         class_dict['thrift_spouts'] = spout_specs
         class_dict['specs'] = list(specs.values())
@@ -118,21 +123,6 @@ class TopologyType(type):
                                          ' {!r} stream.'.format(field,
                                                                 stream_comp.name,
                                                                 stream_id.streamId))
-
-    @classmethod
-    def propogate_config(mcs, config_dict, specs):
-        """Propogate the settings in config to all specs.
-
-        This is necessary because there is no way to set topology-level config
-        options via Thrift.
-        """
-        if not isinstance(config_dict, dict):
-            raise TypeError('Topology config must be a dictionary. Given: {!r}'
-                            .format(config_dict))
-        for spec in itervalues(specs):
-            spec_config_dict = deepcopy(config_dict)
-            spec_config_dict.update(json.loads(spec.config))
-            spec.config = json.dumps(spec_config_dict)
 
     def __repr__(cls):
         """:returns: A string representation of the topology"""


### PR DESCRIPTION
-  Remove --par because it would have made this really really hard.
-  Make --ackers, --debug, and --workers use _StoreDictAction so they just end up in the `arg.options` dict in the end.
-  Remove all the code that was passing them around ackers, debug, and workers.
-  Add a resolve_options function to streamparse.cli.common that takes the env config, the CLI options, and the topology class and spits out a unified options dict.
-  Stop using `TopologyType.propogate_config` to propogate topology-level config options to each component, because this wasn't actually the right way to do it. With the previous approach the options we not actually being set at the topology level, so they didn't show up in Storm UI at the topology level. You had to look at each component separately to see them.