### PR TITLE
Allow empty outputs

### DIFF
--- a/streamparse/dsl/topology.py
+++ b/streamparse/dsl/topology.py
@@ -194,7 +194,7 @@ class Topology(object):
             shell_object = spec.component_object.shell
             flux_dict['constructorArgs'].append([shell_object.execution_command,
                                                  shell_object.script])
-            if not spec.outputs or len(spec.outputs) == 0:
+            if not spec.outputs:
                 flux_dict['constructorArgs'].append(['NONE_BUT_FLUX_WANTS_SOMETHING_HERE'])
             for output_stream in spec.outputs.keys():
                 if output_stream == 'default':

--- a/streamparse/dsl/topology.py
+++ b/streamparse/dsl/topology.py
@@ -194,6 +194,8 @@ class Topology(object):
             shell_object = spec.component_object.shell
             flux_dict['constructorArgs'].append([shell_object.execution_command,
                                                  shell_object.script])
+            if not spec.outputs or len(spec.outputs) == 0:
+                flux_dict['constructorArgs'].append(['NONE_BUT_FLUX_WANTS_SOMETHING_HERE'])
             for output_stream in spec.outputs.keys():
                 if output_stream == 'default':
                     output_fields = spec.outputs['default'].output_fields


### PR DESCRIPTION
Flux expects at least one output if fails on not defined or empty `spec.outputs`. Since empty outputs were supported in all 3.0.0-dev releases this breaks a lot of recent code.