### PR TITLE
add graphviz to requirements file

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 jinja2
 fabric3
+graphviz
 six>=1.5
 requests
 prettytable


### PR DESCRIPTION
Tried to `sparse kill` after 3.0.1 upgrade and got the following error:

```
sparse kill -n <name> -e preprod
Traceback (most recent call last):
  File "/Users/william/anaconda/envs/ds_storm_topologies/bin/sparse", line 11, in <module>
    sys.exit(main())
  File "/Users/william/anaconda/envs/ds_storm_topologies/lib/python2.7/site-packages/streamparse/cli/sparse.py", line 51, in main
    load_subparsers(subparsers)
  File "/Users/william/anaconda/envs/ds_storm_topologies/lib/python2.7/site-packages/streamparse/cli/sparse.py", line 27, in load_subparsers
    module = importlib.import_module('streamparse.cli.{}'.format(mod_name))
  File "/Users/william/anaconda/envs/ds_storm_topologies/lib/python2.7/importlib/__init__.py", line 37, in import_module
    __import__(name)
  File "/Users/william/anaconda/envs/ds_storm_topologies/lib/python2.7/site-packages/streamparse/cli/visualize.py", line 19, in <module>
    raise ImportError('The visualize command requires the `graphviz` Python '
ImportError: The visualize command requires the `graphviz` Python library and `graphviz` system library to be installed.
```

Pip installing graphviz fixed this issue.