### PR TITLE
Added org.apache.storm/flux-core to help string for sparse run.

### DIFF
--- a/streamparse/cli/run.py
+++ b/streamparse/cli/run.py
@@ -2,7 +2,8 @@
 Run a local Storm topology.
 
 Note: If you have "org.apache.storm" in your uberjar-exclusions list in your
-project.clj, this will fail. Temporarily remove it to use `sparse run`.
+project.clj, this will fail. Temporarily remove it to use `sparse run`. You will
+also need to add [org.apache.storm/flux-core "1.0.1"] to dependencies.
 """
 
 from __future__ import absolute_import, print_function


### PR DESCRIPTION
Just removing `#"org.apache.storm"` as per https://github.com/Parsely/streamparse/issues/295 is not enough for local run to work.