### PR TITLE
Add --local_jar_path and --remote_jar_path options to submit

### DIFF
--- a/streamparse/util.py
+++ b/streamparse/util.py
@@ -17,7 +17,7 @@ from socket import error as SocketError
 import requests
 import simplejson as json
 from fabric.api import env, hide, local, settings
-from fabric.colors import red
+from fabric.colors import red, yellow
 from pkg_resources import parse_version
 from prettytable import PrettyTable
 from ruamel import yaml
@@ -138,6 +138,10 @@ def activate_env(env_name=None):
 def die(msg, error_code=1):
     print("{}: {}".format(red("error"), msg))
     sys.exit(error_code)
+
+
+def warn(msg, error_code=1):
+    print("{}: {}".format(yellow("warning"), msg))
 
 
 @memoized


### PR DESCRIPTION
This fixes #332, and can greatly speed up the deployment process when building or uploading the JARs takes a while on your machine.