### PR TITLE
Update Redis Example: Fix AttributeError

### DIFF
--- a/examples/redis/project.clj
+++ b/examples/redis/project.clj
@@ -3,8 +3,8 @@
   :target-path "_build"
   :min-lein-version "2.0.0"
   :jvm-opts ["-client"]
-  :dependencies  [[org.apache.storm/storm-core "1.0.1"]
-                  [org.apache.storm/flux-core "1.0.1"]]
+  :dependencies  [[org.apache.storm/storm-core "1.0.2"]
+                  [org.apache.storm/flux-core "1.0.2"]]
   :jar-exclusions     [#"log4j\.properties" #"org\.apache\.storm\.(?!flux)" #"trident" #"META-INF" #"meta-inf" #"\.yaml"]
   :uberjar-exclusions [#"log4j\.properties" #"org\.apache\.storm\.(?!flux)" #"trident" #"META-INF" #"meta-inf" #"\.yaml"]
   )

--- a/examples/redis/src/bolts.py
+++ b/examples/redis/src/bolts.py
@@ -24,11 +24,18 @@ class WordCountBolt(Bolt):
         self.emit([word, self.counter[word]])
 
 
-class RedisWordCountBolt(WordCountBolt):
+class RedisWordCountBolt(Bolt):
     def initialize(self, conf, ctx):
         self.redis = StrictRedis()
         self.total = 0
 
     def _increment(self, word, inc_by):
         self.total += inc_by
-        self.redis.zincrby("words", word, inc_by)
+        return self.redis.zincrby("words", word, inc_by)
+
+    def process(self, tup):
+        word = tup.values[0]
+        count = self._increment(word, 10 if word == "dog" else 1)
+        if self.total % 1000 == 0:
+            self.logger.info("counted %i words", self.total)
+        self.emit([word, count])


### PR DESCRIPTION
Hi,

First, thanks for building `streamparse`, it's an awesome project!

-----

### What Happened?

I encountered the following while running the provided redis example:

```
28417 [Thread-23] ERROR o.a.s.t.ShellBolt - ShellLog pid:91105, name:count_bolt 2016-11-16 14:35:32,581 - pystorm.component.count_bolt - Exception in RedisWordCountBolt.run()
Traceback (most recent call last):
  File "/Users/cyhsutw/.virtualenvs/streamparse-dev/lib/python2.7/site-packages/pystorm/component.py", line 481, in run
    self._run()
  File "/Users/cyhsutw/.virtualenvs/streamparse-dev/lib/python2.7/site-packages/pystorm/bolt.py", line 197, in _run
    self.process(tup)
  File "/private/var/folders/fl/s44qnfxs6lldrpy8w7k6rd400000gn/T/b34e7e46-7298-4068-89dc-f3f470c61998/supervisor/stormdist/wordcount_redis-1-1479278116/resources/bolts.py", line 24, in process
    self.emit([word, self.counter[word]])
AttributeError: 'RedisWordCountBolt' object has no attribute 'counter'
```

Full log: https://gist.github.com/cyhsutw/999a37329e79b61943540e588289c622

### System Information

- Python: 2.7.12, 3.5.2
- storm: 1.0.2
- streamparse: HEAD@bc49df
- Redis: 3.2.5

### Proposed Solution

Looking into the source files, I found that `RedisWordCountBolt` is a subclass of `WordCountBolt` where the `counter` attribute is defined. However, the `initialize` method in `RedisWordCountBolt` does not call `initialize` on its superclass.

While adding `super(RedisWordCountBolt, self).initialize(conf, ctx)` will fix the issue, I am thinking if we could just separate the implementations of these two classes since they are quite different in data storage.

I've drafted a possible implementation and would love to hear your feedback on it.

### How to Test

1. Spin up a Redis server locally
2. Install dependencies of the example
3. Run `parse run --name wordcount_redis`
4. Watch the activities using `top.sh` and `watch.sh`


Thank you!  😄 
