### PR TITLE
read nimbus config from env variables

### DIFF
--- a/streamparse/util.py
+++ b/streamparse/util.py
@@ -212,18 +212,18 @@ def get_env_config(env_name=None):
 
 
 def get_nimbus_host_port(env_config):
-    """Get the Nimbus server's hostname and port from a streamparse project's
-    config file or from environment variables.
+    """Get the Nimbus server's hostname and port from environment variables
+    or from a streamparse project's config file.
 
     :param env_config: The project's parsed config.
     :type env_config: `dict`
 
     :returns: (host, port)
     """
-    env_config["nimbus"] = env_config["nimbus"] or \
-                                os.environ.get('STREAMPARSE_NIMBUS')
+    env_config["nimbus"] = os.environ.get('STREAMPARSE_NIMBUS',
+                                          env_config["nimbus"])
 
-    if not  env_config["nimbus"]:
+    if not env_config["nimbus"]:
         die("No Nimbus server configured in config.json.")
 
     if ":" in env_config["nimbus"]:

--- a/streamparse/util.py
+++ b/streamparse/util.py
@@ -213,14 +213,17 @@ def get_env_config(env_name=None):
 
 def get_nimbus_host_port(env_config):
     """Get the Nimbus server's hostname and port from a streamparse project's
-    config file.
+    config file or from environment variables.
 
     :param env_config: The project's parsed config.
     :type env_config: `dict`
 
     :returns: (host, port)
     """
-    if not env_config["nimbus"]:
+    env_config["nimbus"] = env_config["nimbus"] or \
+                                os.environ.get('STREAMPARSE_NIMBUS')
+
+    if not  env_config["nimbus"]:
         die("No Nimbus server configured in config.json.")
 
     if ":" in env_config["nimbus"]:


### PR DESCRIPTION
I think it's a good idea to to be able to set some of the streamparse configurations in environment variables, instead of config.json file.