### PR TITLE
Remove extra call to Leiningen

### DIFF
--- a/streamparse/cli/jar.py
+++ b/streamparse/cli/jar.py
@@ -36,7 +36,6 @@ def jar_for_deploy(simple_jar=False):
             raise RuntimeError("Unable to run '{}'!\nSTDOUT:\n{}"
                                "\nSTDERR:\n{}".format(cmd, res.stdout,
                                                       res.stderr))
-        res = local(cmd, capture=True)
     # XXX: This will fail if more than one JAR is built
     lines = res.stdout.splitlines()
     for line in lines:


### PR DESCRIPTION
I initially thought sparse was hanging when creating an uber-jar. After some research, I realized Leiningen ended up taking about 14 minutes to run, and sparse was calling it twice. My performance issue with Leiningen is another issue, but I thought I would at least push this change back.