### PR TITLE
Show output from sparse run.

### DIFF
--- a/streamparse/cli/run.py
+++ b/streamparse/cli/run.py
@@ -11,7 +11,7 @@ from __future__ import absolute_import, print_function
 from argparse import RawDescriptionHelpFormatter
 from tempfile import NamedTemporaryFile
 
-from fabric.api import local
+from fabric.api import local, show
 from ruamel import yaml
 
 from ..util import (get_env_config, get_topology_definition,
@@ -48,15 +48,16 @@ def run_local_topology(name=None, env_name=None, time=0, options=None):
         time = 9223372036854775807  # Max long value in Java
 
     # Write YAML file
-    with NamedTemporaryFile(mode='w', suffix='.yaml', delete=False) as yaml_file:
-        topology_flux_dict = topology_class.to_flux_dict(name)
-        topology_flux_dict['config'] = storm_options
-        yaml.safe_dump(topology_flux_dict, yaml_file)
-        cmd = ('storm jar {jar} org.apache.storm.flux.Flux --local --no-splash '
-               '--sleep {time} {yaml}'.format(jar=topology_jar,
-                                              time=time,
-                                              yaml=yaml_file.name))
-        local(cmd)
+    with show('output'):
+        with NamedTemporaryFile(mode='w', suffix='.yaml', delete=False) as yaml_file:
+            topology_flux_dict = topology_class.to_flux_dict(name)
+            topology_flux_dict['config'] = storm_options
+            yaml.safe_dump(topology_flux_dict, yaml_file)
+            cmd = ('storm jar {jar} org.apache.storm.flux.Flux --local --no-splash '
+                   '--sleep {time} {yaml}'.format(jar=topology_jar,
+                                                  time=time,
+                                                  yaml=yaml_file.name))
+            local(cmd)
 
 
 def subparser_hook(subparsers):


### PR DESCRIPTION
When I run a topology locally with `sparse run`, I don't see any output whatsoever after this:

```
No handlers could be found for logger "pykafka.topic"
Cleaning from prior builds...
Creating topology Uber-JAR...
Uber-JAR created: /Users/irina/repos/engineering/casterisk-realtime/_build/stormtest-0.0.1-SNAPSHOT-standalone.jar
Removing _resources temporary directory...done
```

This fixes the problem.