### PR TITLE
Propagate parallelism to Flux YAML DSL from Python Topology DSL, (#364)

### DIFF
--- a/streamparse/dsl/topology.py
+++ b/streamparse/dsl/topology.py
@@ -210,6 +210,7 @@ class Topology(object):
                             spec.outputs[output_stream].output_fields
                         ]
                     })
+            flux_dict['parallelism'] = spec.par
         else:
             if spec.component_object.serialized_java is not None:
                 raise TypeError('Flux does not support specifying serialized '


### PR DESCRIPTION
Fixes https://github.com/Parsely/streamparse/issues/364.