### PR TITLE
Storm 1.0.3+ Mulitlang resource path support, (#362)

### DIFF
--- a/streamparse/run.py
+++ b/streamparse/run.py
@@ -9,6 +9,7 @@ import sys
 
 from pystorm.component import _SERIALIZERS
 
+RESOURCES_PATH = 'resources'
 
 def main():
     """main entry point for Python bolts and spouts"""
@@ -30,11 +31,12 @@ def main():
     mod_name, cls_name = args.target_class.rsplit('.', 1)
     # Add current directory to sys.path so imports will work
     import_path = os.getcwd()  # Storm <= 1.0.2
-    if 'resources' in next(os.walk(import_path))[1] and \
+    if RESOURCES_PATH in next(os.walk(import_path))[1] and \
        os.path.isfile(os.path.join(import_path,
-                                   'resources',
+                                   RESOURCES_PATH,
                                    mod_name.replace('.', os.path.sep) + '.py')):
-        import_path = os.path.join(import_path, 'resources')  # Storm >= 1.0.3
+        import_path = os.path.join(import_path,
+                                   RESOURCES_PATH)  # Storm >= 1.0.3
     sys.path.append(import_path)
     # Import module
     mod = importlib.import_module(mod_name)

--- a/streamparse/run.py
+++ b/streamparse/run.py
@@ -27,10 +27,16 @@ def main():
     if len(sys.argv) == 2:
         sys.argv = [sys.argv[0]] + sys.argv[1].split()
     args = parser.parse_args()
-    # Add current directory to sys.path so imports will work
-    sys.path.append(os.getcwd())
-    # Import module
     mod_name, cls_name = args.target_class.rsplit('.', 1)
+    # Add current directory to sys.path so imports will work
+    import_path = os.getcwd()  # Storm <= 1.0.2
+    if 'resources' in next(os.walk(import_path))[1] and \
+       os.path.isfile(os.path.join(import_path,
+                                   'resources',
+                                   mod_name.replace('.', os.path.sep) + '.py')):
+        import_path = os.path.join(import_path, 'resources')  # Storm >= 1.0.3
+    sys.path.append(import_path)
+    # Import module
     mod = importlib.import_module(mod_name)
     # Get class from module and run it
     cls = getattr(mod, cls_name)

--- a/test/streamparse/test_streamparse_run.py
+++ b/test/streamparse/test_streamparse_run.py
@@ -17,10 +17,12 @@ class StreamparseRunTests(unittest.TestCase):
 
     def test_streamparse_run_storm_1_0_2(self):
         # patch streamparse_run sys argv assuming tests run
-        # from streamparse project root, (Storm <= 1.0.2 case)
+        # from streamparse project root, (the Storm <= 1.0.2 case):
+        # target test run module specifying absolute import path
+        # including 'test' folder
         sys.argv = ['streamparse_run',
-                    'test.'
-                    'streamparse_run.streamparse_run_target.StreamparseRunTarget']
+                    'test.streamparse_run.streamparse_run_target.StreamparseRunTarget']
+        # invoke run module main
         StreamparseRunTests.run_target_invoked = False
         StreamparseRunTests.run_target_invoked_serializer = None
         run.main()
@@ -29,12 +31,15 @@ class StreamparseRunTests(unittest.TestCase):
 
     def test_streamparse_run_storm_1_0_3(self):
         # patch streamparse_run resources path and sys argv
-        # assuming tests run from streamparse project root,
-        # (Storm >= 1.0.3 case)
+        # assuming tests run from streamparse project root
+        # with 'extra' resources folder, (Storm >= 1.0.3 case):
+        # target test run module specifying relative import
+        # path within 'test' resources folder; also test
+        # serializer option
         run.RESOURCES_PATH = 'test'
         sys.argv = ['streamparse_run',
-                    'streamparse_run.streamparse_run_target.StreamparseRunTarget '
-                    '--serializer=msgpack']
+                    'streamparse_run.streamparse_run_target.StreamparseRunTarget --serializer=msgpack']
+        # invoke run module main
         StreamparseRunTests.run_target_invoked = False
         StreamparseRunTests.run_target_invoked_serializer = None
         run.main()

--- a/test/streamparse/test_streamparse_run.py
+++ b/test/streamparse/test_streamparse_run.py
@@ -1,0 +1,42 @@
+"""
+Tests for streamparse_run
+"""
+
+import logging
+import os
+import sys
+import unittest
+
+from streamparse import run
+
+
+class StreamparseRunTests(unittest.TestCase):
+
+    run_target_invoked = False
+    run_target_invoked_serializer = None
+
+    def test_streamparse_run_storm_1_0_2(self):
+        # patch streamparse_run sys argv assuming tests run
+        # from streamparse project root, (Storm <= 1.0.2 case)
+        sys.argv = ['streamparse_run',
+                    'test.'
+                    'streamparse_run.streamparse_run_target.StreamparseRunTarget']
+        StreamparseRunTests.run_target_invoked = False
+        StreamparseRunTests.run_target_invoked_serializer = None
+        run.main()
+        self.assertTrue(StreamparseRunTests.run_target_invoked)
+        self.assertEquals('json', StreamparseRunTests.run_target_invoked_serializer)
+
+    def test_streamparse_run_storm_1_0_3(self):
+        # patch streamparse_run resources path and sys argv
+        # assuming tests run from streamparse project root,
+        # (Storm >= 1.0.3 case)
+        run.RESOURCES_PATH = 'test'
+        sys.argv = ['streamparse_run',
+                    'streamparse_run.streamparse_run_target.StreamparseRunTarget '
+                    '--serializer=msgpack']
+        StreamparseRunTests.run_target_invoked = False
+        StreamparseRunTests.run_target_invoked_serializer = None
+        run.main()
+        self.assertTrue(StreamparseRunTests.run_target_invoked)
+        self.assertEquals('msgpack', StreamparseRunTests.run_target_invoked_serializer)

--- a/test/streamparse_run/streamparse_run_target.py
+++ b/test/streamparse_run/streamparse_run_target.py
@@ -1,0 +1,15 @@
+"""
+Test target for streamparse_run
+"""
+
+from test.streamparse.test_streamparse_run import StreamparseRunTests
+
+
+class StreamparseRunTarget(object):
+
+    def __init__(self, serializer):
+        self.serializer = serializer
+
+    def run(self):
+        StreamparseRunTests.run_target_invoked = True
+        StreamparseRunTests.run_target_invoked_serializer = self.serializer


### PR DESCRIPTION
Add 'resource' path to load spout/bolt components in streamparse_run for Storm 1.0.3.