### PR TITLE
added virtualenv_name config

### DIFF
--- a/doc/source/quickstart.rst
+++ b/doc/source/quickstart.rst
@@ -411,6 +411,12 @@ If you would like to pass command-line flags to virtualenv, you can set
 Note that this only applies when the virtualenv is created, not when an
 existing virtualenv is used.
 
+If you would like to share a single virtualenv across topologies, you can set
+``"virtualenv_name"`` in ``config.json`` which overrides the default behaviour
+of using the topology name for virtualenv. Updates to a shared virtualenv should
+be done after shutting down topologies, as code changes in running topologies
+may cause errors.
+
 Using unofficial versions of Storm
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/streamparse/cli/common.py
+++ b/streamparse/cli/common.py
@@ -106,6 +106,14 @@ def add_override_name(parser):
                              'duplicate the topology file.')
 
 
+def add_virtualenv_name(parser):
+    """ Add --virtualenv_name option to parser """
+    parser.add_argument('-V', '--virtualenv_name',
+                        help='Override virtualenv name when submitting topologies.'
+                             'It takes precedence over "--override-name" and is only'
+                             'used only when "use_virtualenv" is set to True.')
+
+
 def add_pattern(parser):
     """ Add --pattern option to parser """
     parser.add_argument('--pattern',

--- a/streamparse/cli/common.py
+++ b/streamparse/cli/common.py
@@ -106,14 +106,6 @@ def add_override_name(parser):
                              'duplicate the topology file.')
 
 
-def add_virtualenv_name(parser):
-    """ Add --virtualenv_name option to parser """
-    parser.add_argument('-V', '--virtualenv_name',
-                        help='Override virtualenv name when submitting topologies.'
-                             'It takes precedence over "--override-name" and is only'
-                             'used only when "use_virtualenv" is set to True.')
-
-
 def add_pattern(parser):
     """ Add --pattern option to parser """
     parser.add_argument('--pattern',

--- a/streamparse/cli/submit.py
+++ b/streamparse/cli/submit.py
@@ -171,12 +171,12 @@ def submit_topology(name=None, env_name=None, options=None, force=False,
 
     # If using virtualenv, set it up, and make sure paths are correct in specs
     if use_venv:
-        virtualenv_override_name = env_config.get('virtualenv_name', override_name)
+        virtualenv_name = env_config.get('virtualenv_name', override_name)
         if install_venv:
             create_or_update_virtualenvs(env_name, name,
-                                         virtualenv_override_name=virtualenv_override_name,
+                                         virtualenv_name=virtualenv_name,
                                          requirements_paths=requirements_paths)
-        streamparse_run_path = '/'.join([env.virtualenv_root, virtualenv_override_name,
+        streamparse_run_path = '/'.join([env.virtualenv_root, virtualenv_name,
                                          'bin', 'streamparse_run'])
         # Update python paths in bolts
         for thrift_bolt in itervalues(topology_class.thrift_bolts):

--- a/streamparse/cli/submit.py
+++ b/streamparse/cli/submit.py
@@ -171,11 +171,12 @@ def submit_topology(name=None, env_name=None, options=None, force=False,
 
     # If using virtualenv, set it up, and make sure paths are correct in specs
     if use_venv:
+        virtualenv_override_name = env_config.get('virtualenv_name', override_name)
         if install_venv:
             create_or_update_virtualenvs(env_name, name,
-                                         override_name=override_name,
+                                         virtualenv_override_name=virtualenv_override_name,
                                          requirements_paths=requirements_paths)
-        streamparse_run_path = '/'.join([env.virtualenv_root, override_name,
+        streamparse_run_path = '/'.join([env.virtualenv_root, virtualenv_override_name,
                                          'bin', 'streamparse_run'])
         # Update python paths in bolts
         for thrift_bolt in itervalues(topology_class.thrift_bolts):

--- a/streamparse/cli/update_virtualenv.py
+++ b/streamparse/cli/update_virtualenv.py
@@ -51,7 +51,7 @@ def _create_or_update_virtualenv(virtualenv_root,
             run("rm {}".format(temp_req))
 
 
-def create_or_update_virtualenvs(env_name, topology_name, virtualenv_override_name=None,
+def create_or_update_virtualenvs(env_name, topology_name, virtualenv_name=None,
                                  requirements_paths=None):
     """Create or update virtualenvs on remote servers.
 
@@ -59,7 +59,7 @@ def create_or_update_virtualenvs(env_name, topology_name, virtualenv_override_na
 
     :param env_name: the name of the environment in config.json.
     :param topology_name: the name of the topology (and virtualenv).
-    :param virtualenv_override_name: the name that we should use for the virtualenv, even
+    :param virtualenv_name: the name that we should use for the virtualenv, even
                           though the topology file has a different name.
     :param requirements_paths: a list of paths to requirements files to use to
                                create virtualenv
@@ -67,8 +67,8 @@ def create_or_update_virtualenvs(env_name, topology_name, virtualenv_override_na
     config = get_config()
     topology_name = get_topology_definition(topology_name)[0]
     env_name, env_config = get_env_config(env_name)
-    if virtualenv_override_name is None:
-        virtualenv_override_name = topology_name
+    if virtualenv_name is None:
+        virtualenv_name = topology_name
 
     config["virtualenv_specs"] = config["virtualenv_specs"].rstrip("/")
 
@@ -94,7 +94,7 @@ def create_or_update_virtualenvs(env_name, topology_name, virtualenv_override_na
     activate_env(env_name)
 
     # Actually create or update virtualenv on worker nodes
-    execute(_create_or_update_virtualenv, env.virtualenv_root, virtualenv_override_name,
+    execute(_create_or_update_virtualenv, env.virtualenv_root, virtualenv_name,
             requirements_paths,
             virtualenv_flags=env_config.get('virtualenv_flags'),
             hosts=env.storm_workers)
@@ -115,5 +115,5 @@ def subparser_hook(subparsers):
 def main(args):
     """ Create or update a virtualenv on Storm workers. """
     create_or_update_virtualenvs(args.environment, args.name,
-                                 virtualenv_override_name=args.override_name,
+                                 virtualenv_name=args.override_name,
                                  requirements_paths=args.requirements)

--- a/streamparse/cli/update_virtualenv.py
+++ b/streamparse/cli/update_virtualenv.py
@@ -51,7 +51,7 @@ def _create_or_update_virtualenv(virtualenv_root,
             run("rm {}".format(temp_req))
 
 
-def create_or_update_virtualenvs(env_name, topology_name, override_name=None,
+def create_or_update_virtualenvs(env_name, topology_name, virtualenv_override_name=None,
                                  requirements_paths=None):
     """Create or update virtualenvs on remote servers.
 
@@ -59,7 +59,7 @@ def create_or_update_virtualenvs(env_name, topology_name, override_name=None,
 
     :param env_name: the name of the environment in config.json.
     :param topology_name: the name of the topology (and virtualenv).
-    :param override_name: the name that we should use for the virtualenv, even
+    :param virtualenv_override_name: the name that we should use for the virtualenv, even
                           though the topology file has a different name.
     :param requirements_paths: a list of paths to requirements files to use to
                                create virtualenv
@@ -67,8 +67,8 @@ def create_or_update_virtualenvs(env_name, topology_name, override_name=None,
     config = get_config()
     topology_name = get_topology_definition(topology_name)[0]
     env_name, env_config = get_env_config(env_name)
-    if override_name is None:
-        override_name = topology_name
+    if virtualenv_override_name is None:
+        virtualenv_override_name = topology_name
 
     config["virtualenv_specs"] = config["virtualenv_specs"].rstrip("/")
 
@@ -94,7 +94,7 @@ def create_or_update_virtualenvs(env_name, topology_name, override_name=None,
     activate_env(env_name)
 
     # Actually create or update virtualenv on worker nodes
-    execute(_create_or_update_virtualenv, env.virtualenv_root, override_name,
+    execute(_create_or_update_virtualenv, env.virtualenv_root, virtualenv_override_name,
             requirements_paths,
             virtualenv_flags=env_config.get('virtualenv_flags'),
             hosts=env.storm_workers)
@@ -115,5 +115,5 @@ def subparser_hook(subparsers):
 def main(args):
     """ Create or update a virtualenv on Storm workers. """
     create_or_update_virtualenvs(args.environment, args.name,
-                                 override_name=args.override_name,
+                                 virtualenv_override_name=args.override_name,
                                  requirements_paths=args.requirements)


### PR DESCRIPTION
Introduced `virtualenv_name` in the config.json which overrides the default virtualenv(topology name) that streamparse uses when topologies are deployed.

This would take precedence over topology `override_name` and will only be used when `use_virtualenv` is True.

[Issue 371](https://github.com/Parsely/streamparse/issues/371)