### PR TITLE
fix ruamel.yaml on 0.14.X for now

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ setuptools
 simplejson
 pystorm>=3.1.0
 thriftpy>=0.3.2
-ruamel.yaml
+ruamel.yaml<0.15

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ install_requires = [
     'simplejson',
     'pystorm>=3.1.0',
     'thriftpy>=0.3.2',
-    'ruamel.yaml'
+    'ruamel.yaml<0.15',
 ]
 
 if sys.version_info.major < 3:


### PR DESCRIPTION
Thank you for using ruamel.yaml. 

There will be API changes in the 0.15+ versions, that might lead to warnings that 
your users could see. 
Therefore please release a version of your package with this change, so that it will not 
automatically take the latest ruamel.yaml release.
