### PR TITLE
Add --timeout option to commands that talk to Nimbus via Thrift

### DIFF
--- a/streamparse/cli/common.py
+++ b/streamparse/cli/common.py
@@ -141,6 +141,15 @@ def add_simple_jar(parser):
                              'dependencies.')
 
 
+def add_timeout(parser):
+    """ Add --timeout option to parser """
+    parser.add_argument('--timeout',
+                        type=int,
+                        default=7000,
+                        help='Milliseconds to wait for Nimbus to respond. '
+                             '(default: %(default)s)')
+
+
 def add_wait(parser):
     """ Add --wait option to parser """
     parser.add_argument('--wait',

--- a/streamparse/cli/kill.py
+++ b/streamparse/cli/kill.py
@@ -7,7 +7,7 @@ from __future__ import absolute_import
 from ..thrift import KillOptions
 from ..util import (get_topology_definition, get_env_config, get_nimbus_client,
                     ssh_tunnel)
-from .common import add_environment, add_name, add_wait
+from .common import add_environment, add_name, add_timeout, add_wait
 
 
 def _kill_topology(topology_name, nimbus_client, wait=None):
@@ -15,7 +15,7 @@ def _kill_topology(topology_name, nimbus_client, wait=None):
     nimbus_client.killTopologyWithOpts(name=topology_name, options=kill_opts)
 
 
-def kill_topology(topology_name=None, env_name=None, wait=None):
+def kill_topology(topology_name=None, env_name=None, wait=None, timeout=None):
     # For kill, we allow any topology name to be specified, because people
     # should be able to kill topologies not in their local branch
     if topology_name is None:
@@ -23,7 +23,8 @@ def kill_topology(topology_name=None, env_name=None, wait=None):
     env_name, env_config = get_env_config(env_name)
     # Use ssh tunnel with Nimbus if use_ssh_for_nimbus is unspecified or True
     with ssh_tunnel(env_config) as (host, port):
-        nimbus_client = get_nimbus_client(env_config, host=host, port=port)
+        nimbus_client = get_nimbus_client(env_config, host=host, port=port,
+                                          timeout=timeout)
         return _kill_topology(topology_name, nimbus_client, wait=wait)
 
 
@@ -35,10 +36,11 @@ def subparser_hook(subparsers):
     subparser.set_defaults(func=main)
     add_environment(subparser)
     add_name(subparser)
+    add_timeout(subparser)
     add_wait(subparser)
 
 
 def main(args):
     """ Kill the specified Storm topology """
     kill_topology(topology_name=args.name, env_name=args.environment,
-                  wait=args.wait)
+                  wait=args.wait, timeout=args.timeout)

--- a/streamparse/cli/list.py
+++ b/streamparse/cli/list.py
@@ -7,7 +7,7 @@ from __future__ import absolute_import
 from ..util import (get_env_config, get_nimbus_client, print_stats_table,
                     ssh_tunnel)
 from ..thrift import TopologySummary
-from .common import add_environment
+from .common import add_environment, add_timeout
 
 
 def _list_topologies(nimbus_client):
@@ -16,12 +16,13 @@ def _list_topologies(nimbus_client):
     return cluster_summary.topologies
 
 
-def list_topologies(env_name):
+def list_topologies(env_name, timeout=None):
     """Prints out all running Storm topologies"""
     env_name, env_config = get_env_config(env_name)
     # Use ssh tunnel with Nimbus if use_ssh_for_nimbus is unspecified or True
     with ssh_tunnel(env_config) as (host, port):
-        nimbus_client = get_nimbus_client(env_config, host=host, port=port)
+        nimbus_client = get_nimbus_client(env_config, host=host, port=port,
+                                          timeout=timeout)
         topologies = _list_topologies(nimbus_client)
     if not topologies:
         print('No topologies found.')
@@ -37,8 +38,9 @@ def subparser_hook(subparsers):
                                       help=main.__doc__)
     subparser.set_defaults(func=main)
     add_environment(subparser)
+    add_timeout(subparser)
 
 
 def main(args):
     """ List the currently running Storm topologies """
-    list_topologies(args.environment)
+    list_topologies(args.environment, timeout=args.timeout)


### PR DESCRIPTION
This will let people temporarily bump out their timeouts if they're trying to submit topologies on slower internet connections.

This fixes #341.