### PR TITLE
Add dynamic lookup of storm supervisors

### DIFF
--- a/doc/source/faq.rst
+++ b/doc/source/faq.rst
@@ -157,8 +157,8 @@ In a small cluster it's sufficient to specify the list of workers in ``config.js
 However, if you have a large or complex environment where workers are numerous 
 or short-lived, ``streamparse`` supports querying the nimbus server for a list of hosts.
 
-An undefined list of ``workers`` will trigger the lookup. Explicitly defined
-hosts are preferred over a lookup, even if the list of workers is empty.
+An undefined list (empty or None) of ``workers`` will trigger the lookup. 
+Explicitly defined hosts are preferred over a lookup.
 
 Lookups are configured on a per-environment basis, so the ``prod`` environment 
 below uses the dynamic lookup, while ``beta`` will not.

--- a/doc/source/faq.rst
+++ b/doc/source/faq.rst
@@ -12,6 +12,7 @@ General Questions
 * `Should I install Clojure?`_
 * `How do I deploy into a VPC?`_
 * `How do I override SSH settings?`_
+* `How do I dynamically generate the worker list?`_
 
 
 Why use streamparse?
@@ -147,3 +148,43 @@ the ``ssh_password`` or ``ssh_port`` environment settings.
             }
         }
     }
+
+
+How do I dynamically generate the worker list?
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+In a small cluster it's sufficient to specify the list of workers in ``config.json``. 
+However, if you have a large or complex environment where workers are numerous 
+or short-lived, ``streamparse`` supports querying the nimbus server for a list of hosts.
+
+To trigger the dynamic lookup, the ``workers`` list should be empty or undefined.
+Disable this lookup (and use the empty list) by setting ``allow_worker_lookup: false``.
+Explicitly defined hosts are preferred over a lookup, even if the feature is enabled,
+as it is by default.
+
+Lookups are configured on a per-environment basis, so the ``prod`` environment 
+below uses the dynamic lookup, while ``beta`` will not, even if the worker list
+was cleared. 
+
+.. code-block:: json
+
+    {
+        "topology_specs": "topologies/",
+        "virtualenv_specs": "virtualenvs/",
+        "envs": {
+            "prod": {
+                "nimbus": "streamparse-prod",
+                "workers": [],
+                "virtualenv_root": "/data/virtualenvs"
+            },
+            "beta": {
+                "nimbus": "streamparse-beta",
+                "workers": [
+                    "streamparse-beta"
+                ],
+                "allow_worker_lookup": false,
+                "virtualenv_root": "/data/virtualenvs"
+            }
+        }
+    }
+

--- a/doc/source/faq.rst
+++ b/doc/source/faq.rst
@@ -157,14 +157,11 @@ In a small cluster it's sufficient to specify the list of workers in ``config.js
 However, if you have a large or complex environment where workers are numerous 
 or short-lived, ``streamparse`` supports querying the nimbus server for a list of hosts.
 
-To trigger the dynamic lookup, the ``workers`` list should be empty or undefined.
-Disable this lookup (and use the empty list) by setting ``allow_worker_lookup: false``.
-Explicitly defined hosts are preferred over a lookup, even if the feature is enabled,
-as it is by default.
+An undefined list of ``workers`` will trigger the lookup. Explicitly defined
+hosts are preferred over a lookup, even if the list of workers is empty.
 
 Lookups are configured on a per-environment basis, so the ``prod`` environment 
-below uses the dynamic lookup, while ``beta`` will not, even if the worker list
-was cleared. 
+below uses the dynamic lookup, while ``beta`` will not.
 
 .. code-block:: json
 
@@ -174,7 +171,6 @@ was cleared.
         "envs": {
             "prod": {
                 "nimbus": "streamparse-prod",
-                "workers": [],
                 "virtualenv_root": "/data/virtualenvs"
             },
             "beta": {
@@ -182,7 +178,6 @@ was cleared.
                 "workers": [
                     "streamparse-beta"
                 ],
-                "allow_worker_lookup": false,
                 "virtualenv_root": "/data/virtualenvs"
             }
         }

--- a/doc/source/topologies.rst
+++ b/doc/source/topologies.rst
@@ -259,7 +259,7 @@ of 2 workers, which are independent JVM processes for Storm. This allows a
 topology to continue running when one worker process dies; the other is around
 until the dead process restarts.
 
-Both ``sparse run`` and ``sparse sumbit`` accept a ``-p N`` command-line flag
+Both ``sparse run`` and ``sparse submit`` accept a ``-p N`` command-line flag
 to set the number of topology workers to N. For convenience, this flag also
 sets the number of `Storm's underlying messaging reliability
 <https://storm.apache.org/documentation/Guaranteeing-message-processing.html>`_

--- a/streamparse/util.py
+++ b/streamparse/util.py
@@ -274,8 +274,8 @@ def get_storm_workers(env_config):
     if nimbus_info in _storm_workers:
         return _storm_workers[nimbus_info]
 
-    worker_list = env_config.get('workers', None)
-    if worker_list is None:
+    worker_list = env_config.get('workers')
+    if not worker_list:
         with ssh_tunnel(env_config) as (host, port):
             nimbus_client = get_nimbus_client(env_config, host=host, port=port)
             cluster_info = nimbus_client.getClusterInfo()

--- a/streamparse/util.py
+++ b/streamparse/util.py
@@ -263,20 +263,19 @@ _storm_workers = {}
 def get_storm_workers(env_config):
     """Retrieves list of workers, optionally from nimbus
 
-    This function will look up the list of current workers from nimbus unless
-    `allow_worker_lookup: False` is set in `env_config` or if a list of workers
-    has been provided in `env_config`.
+    This function will look up the list of current workers from nimbus if
+    workers has not been defined in config.json
     :param env_config: The project's parsed config.
     :type env_config: `dict`
 
     :returns: List of workers
     """
     nimbus_info = get_nimbus_host_port(env_config)
-    if _storm_workers.get(nimbus_info):
+    if nimbus_info in _storm_workers:
         return _storm_workers[nimbus_info]
 
-    worker_list = env_config.get('workers', [])
-    if not worker_list and env_config.get('allow_worker_lookup', True):
+    worker_list = env_config.get('workers', None)
+    if worker_list is None:
         with ssh_tunnel(env_config) as (host, port):
             nimbus_client = get_nimbus_client(env_config, host=host, port=port)
             cluster_info = nimbus_client.getClusterInfo()


### PR DESCRIPTION
Look up the storm workers from the nimbus server unless hostnames are explicitly defined in `config.json`, or the network lookup is explicitly prohibited (also in `config.json`). This will allow more dynamic expansion of storm clusters without requiring hostname list updates.

Also added documentation about this lookup to FAQ