### PR TITLE
Pass storm workers to topology on deploy as storm.workers.list

### DIFF
--- a/streamparse/cli/common.py
+++ b/streamparse/cli/common.py
@@ -230,8 +230,10 @@ def resolve_options(cli_options, env_config, topology_class, topology_name,
 
     # If ackers and executors still aren't set, use number of worker nodes
     if not local_only:
-        num_storm_workers = len(get_storm_workers(env_config))
+        storm_options['storm.workers.list'] = get_storm_workers(env_config)
+        num_storm_workers = len(storm_options['storm.workers.list'])
     else:
+        storm_options['storm.workers.list'] = []
         num_storm_workers = 1
     if storm_options.get('topology.acker.executors') is None:
         storm_options['topology.acker.executors'] = num_storm_workers


### PR DESCRIPTION
This way if you've got a topology that you would like to use the worker list at runtime, you don't have to have each executor query nimbus for the worker list.