### PR TITLE
make cli options available to pre_submit_hooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ _resources/
 *.sw*
 .tox/
 .python-version
+.*.un~

--- a/streamparse/cli/common.py
+++ b/streamparse/cli/common.py
@@ -230,7 +230,10 @@ def resolve_options(cli_options, env_config, topology_class, topology_name,
 
     # If ackers and executors still aren't set, use number of worker nodes
     if not local_only:
-        storm_options['storm.workers.list'] = get_storm_workers(env_config)
+        if 'storm.workers.list' not in storm_options:
+            storm_options['storm.workers.list'] = get_storm_workers(env_config)
+        else:
+            storm_options['storm.workers.list'] = storm_options['storm.workers.list'].split(",")
         num_storm_workers = len(storm_options['storm.workers.list'])
     else:
         storm_options['storm.workers.list'] = []

--- a/streamparse/cli/common.py
+++ b/streamparse/cli/common.py
@@ -230,9 +230,9 @@ def resolve_options(cli_options, env_config, topology_class, topology_name,
 
     # If ackers and executors still aren't set, use number of worker nodes
     if not local_only:
-        if 'storm.workers.list' not in storm_options:
+        if not storm_options.get('storm.workers.list'):
             storm_options['storm.workers.list'] = get_storm_workers(env_config)
-        else:
+        elif isinstance(storm_options['storm.workers.list'], string_types):
             storm_options['storm.workers.list'] = storm_options['storm.workers.list'].split(",")
         num_storm_workers = len(storm_options['storm.workers.list'])
     else:

--- a/streamparse/cli/remove_logs.py
+++ b/streamparse/cli/remove_logs.py
@@ -32,7 +32,7 @@ def _remove_logs(topology_name, pattern, remove_worker_logs, user, is_old_storm,
 
 def remove_logs(topology_name=None, env_name=None, pattern=None,
                 remove_worker_logs=False, user='root', override_name=None,
-                remove_all_artifacts=False):
+                remove_all_artifacts=False, options=None):
     """Remove all Python logs on Storm workers in the log.path directory."""
     if override_name is not None:
         topology_name = override_name
@@ -42,7 +42,7 @@ def remove_logs(topology_name=None, env_name=None, pattern=None,
     with ssh_tunnel(env_config) as (host, port):
         nimbus_client = get_nimbus_client(env_config, host=host, port=port)
         is_old_storm = nimbus_storm_version(nimbus_client) < parse_version('1.0')
-    activate_env(env_name)
+    activate_env(env_name, options=options)
     execute(_remove_logs, topology_name, pattern, remove_worker_logs, user,
             is_old_storm, remove_all_artifacts, hosts=env.storm_workers)
 

--- a/streamparse/cli/submit.py
+++ b/streamparse/cli/submit.py
@@ -100,15 +100,15 @@ def _pre_submit_hooks(topology_name, env_name, env_config, options):
         pre_submit_fabric(topology_name, env_name, env_config, options)
 
 
-def _post_submit_hooks(topology_name, env_name, env_config):
+def _post_submit_hooks(topology_name, env_name, env_config, options):
     """Post-submit hooks for invoke and fabric."""
     user_invoke, user_fabric = get_user_tasks()
     post_submit_invoke = getattr(user_invoke, "post_submit", None)
     if callable(post_submit_invoke):
-        post_submit_invoke(topology_name, env_name, env_config)
+        post_submit_invoke(topology_name, env_name, env_config, options)
     post_submit_fabric = getattr(user_fabric, "post_submit", None)
     if callable(post_submit_fabric):
-        post_submit_fabric(topology_name, env_name, env_config)
+        post_submit_fabric(topology_name, env_name, env_config, options)
 
 
 def _upload_jar(nimbus_client, local_path):
@@ -225,7 +225,7 @@ def submit_topology(name=None, env_name=None, options=None, force=False,
         _kill_existing_topology(override_name, force, wait, nimbus_client)
         _submit_topology(override_name, topology_class, remote_jar_path, config,
                          env_config, nimbus_client, options=options)
-    _post_submit_hooks(override_name, env_name, env_config)
+    _post_submit_hooks(override_name, env_name, env_config, options)
 
 
 def subparser_hook(subparsers):

--- a/streamparse/cli/update_virtualenv.py
+++ b/streamparse/cli/update_virtualenv.py
@@ -51,7 +51,7 @@ def _create_or_update_virtualenv(virtualenv_root,
             run("rm {}".format(temp_req))
 
 
-def create_or_update_virtualenvs(env_name, topology_name, virtualenv_name=None,
+def create_or_update_virtualenvs(env_name, topology_name, options, virtualenv_name=None,
                                  requirements_paths=None):
     """Create or update virtualenvs on remote servers.
 
@@ -91,7 +91,7 @@ def create_or_update_virtualenvs(env_name, topology_name, virtualenv_name=None,
             .format(requirements_paths))
 
     # Setup the fabric env dictionary
-    activate_env(env_name)
+    activate_env(env_name, options)
 
     # Actually create or update virtualenv on worker nodes
     execute(_create_or_update_virtualenv, env.virtualenv_root, virtualenv_name,

--- a/streamparse/util.py
+++ b/streamparse/util.py
@@ -110,7 +110,7 @@ def ssh_tunnel(env_config, local_port=6627, remote_port=None, quiet=False):
         yield host, remote_port
 
 
-def activate_env(env_name=None):
+def activate_env(env_name=None, options=None):
     """Activate a particular environment from a streamparse project's
     config.json file and populate fabric's env dictionary with appropriate
     values.
@@ -120,7 +120,10 @@ def activate_env(env_name=None):
     """
     env_name, env_config = get_env_config(env_name)
 
-    env.storm_workers = get_storm_workers(env_config)
+    if options and 'storm.workers.list' in options:
+        env.storm_workers = options['storm.workers.list']
+    else:
+        env.storm_workers = get_storm_workers(env_config)
     env.user = env_config.get("user")
     env.log_path = (env_config.get("log_path") or
                     env_config.get("log", {}).get("path") or

--- a/streamparse/util.py
+++ b/streamparse/util.py
@@ -120,7 +120,7 @@ def activate_env(env_name=None, options=None):
     """
     env_name, env_config = get_env_config(env_name)
 
-    if options and 'storm.workers.list' in options:
+    if options and options.get('storm.workers.list'):
         env.storm_workers = options['storm.workers.list']
     else:
         env.storm_workers = get_storm_workers(env_config)


### PR DESCRIPTION
This PR makes CLI options available to `pre_submit_hooks`, as well as passing them to `create_or_update_virtualenvs`. It also ensures that `storm.workers.list` set on the CLI is used in these contexts. This allows client programs to override the storm workers list from the CLI. 