### PR TITLE
Small fix args !- arg for custom class builder

### DIFF
--- a/streamparse/dsl/stream.py
+++ b/streamparse/dsl/stream.py
@@ -121,8 +121,8 @@ class Grouping(object):
     def custom_object(cls, java_class_name, arg_list):
         """Tuples will be assigned to tasks by the given Java class."""
         java_object = JavaObject(full_class_name=java_class_name,
-                                 arg_list=[to_java_arg(arg)
-                                           for arg in arg_list])
+                                 args_list=[to_java_arg(arg)
+                                            for arg in arg_list])
         return _Grouping(custom_object=java_object)
 
     @classmethod

--- a/streamparse/dsl/topology.py
+++ b/streamparse/dsl/topology.py
@@ -246,7 +246,7 @@ class Topology(object):
                 elif key == 'custom_object':
                     grouping_dict['type'] = 'CUSTOM'
                     class_dict = {'className': val.full_class_name,
-                                  'args': to_python_arg_list(val.arg_list)}
+                                  'constructorArgs': to_python_arg_list(val.args_list)}
                     grouping_dict['customClass'] = class_dict
         flux_dict['grouping'] = grouping_dict
         return flux_dict


### PR DESCRIPTION
Small fix I found while testing out the custom class builder. I left the API the same, even though it's singular and I think everything else is plural now.