### PR TITLE
Add submit argument to allow skipping virtualenv requirement install

### DIFF
--- a/streamparse/cli/submit.py
+++ b/streamparse/cli/submit.py
@@ -145,8 +145,7 @@ def submit_topology(name=None, env_name=None, options=None, force=False,
                     wait=None, simple_jar=True, override_name=None,
                     requirements_paths=None, local_jar_path=None,
                     remote_jar_path=None, timeout=None, config_file=None,
-                    overwrite_virtualenv=False, skip_virtualenv=False,
-                    user='root'):
+                    overwrite_virtualenv=False, user='root'):
     """Submit a topology to a remote Storm cluster."""
     config = get_config(config_file=config_file)
     name, topology_file = get_topology_definition(name, config_file=config_file)
@@ -162,7 +161,7 @@ def submit_topology(name=None, env_name=None, options=None, force=False,
     use_venv = env_config.get('use_virtualenv', True)
 
     # Check if user wants to install virtualenv during the process
-    install_venv = env_config.get('install_virtualenv', not skip_virtualenv)
+    install_venv = env_config.get('install_virtualenv', use_venv)
 
     # Setup the fabric env dictionary
     activate_env(env_name)
@@ -265,12 +264,6 @@ def subparser_hook(subparsers):
     add_options(subparser)
     add_override_name(subparser)
     add_overwrite_virtualenv(subparser)
-    subparser.add_argument( '--skip-virtualenv',
-                           action='store_true',
-                           help='Skip the installation of virtualenv requirements. '
-                                'This is useful when submitting a topology multiple times '
-                                'but its virtualenv already exists and no requirements have '
-                                'changed, so requirement installation can be safely skipped.')
     add_pool_size(subparser)
     add_requirements(subparser)
     subparser.add_argument('-R', '--remote_jar_path',
@@ -303,5 +296,4 @@ def main(args):
                     timeout=args.timeout,
                     config_file=args.config,
                     overwrite_virtualenv=args.overwrite_virtualenv,
-                    skip_virtualenv=args.skip_virtualenv,
                     user=args.user)

--- a/streamparse/cli/submit.py
+++ b/streamparse/cli/submit.py
@@ -145,7 +145,8 @@ def submit_topology(name=None, env_name=None, options=None, force=False,
                     wait=None, simple_jar=True, override_name=None,
                     requirements_paths=None, local_jar_path=None,
                     remote_jar_path=None, timeout=None, config_file=None,
-                    overwrite_virtualenv=False, user='root'):
+                    overwrite_virtualenv=False, skip_virtualenv=False,
+                    user='root'):
     """Submit a topology to a remote Storm cluster."""
     config = get_config(config_file=config_file)
     name, topology_file = get_topology_definition(name, config_file=config_file)
@@ -161,7 +162,7 @@ def submit_topology(name=None, env_name=None, options=None, force=False,
     use_venv = env_config.get('use_virtualenv', True)
 
     # Check if user wants to install virtualenv during the process
-    install_venv = env_config.get('install_virtualenv', use_venv)
+    install_venv = env_config.get('install_virtualenv', not skip_virtualenv)
 
     # Setup the fabric env dictionary
     activate_env(env_name)
@@ -264,6 +265,12 @@ def subparser_hook(subparsers):
     add_options(subparser)
     add_override_name(subparser)
     add_overwrite_virtualenv(subparser)
+    subparser.add_argument( '--skip-virtualenv',
+                           action='store_true',
+                           help='Skip the installation of virtualenv requirements. '
+                                'This is useful when submitting a topology multiple times '
+                                'but its virtualenv already exists and no requirements have '
+                                'changed, so requirement installation can be safely skipped.')
     add_pool_size(subparser)
     add_requirements(subparser)
     subparser.add_argument('-R', '--remote_jar_path',
@@ -296,4 +303,5 @@ def main(args):
                     timeout=args.timeout,
                     config_file=args.config,
                     overwrite_virtualenv=args.overwrite_virtualenv,
+                    skip_virtualenv=args.skip_virtualenv,
                     user=args.user)

--- a/streamparse/cli/submit.py
+++ b/streamparse/cli/submit.py
@@ -157,12 +157,6 @@ def submit_topology(name=None, env_name=None, options=None, force=False,
         warn('Ignoring local_jar_path because given remote_jar_path')
         local_jar_path = None
 
-    # Check if we need to maintain virtualenv during the process
-    use_venv = env_config.get('use_virtualenv', True)
-
-    # Check if user wants to install virtualenv during the process
-    install_venv = env_config.get('install_virtualenv', use_venv)
-
     # Setup the fabric env dictionary
     activate_env(env_name)
 
@@ -170,12 +164,18 @@ def submit_topology(name=None, env_name=None, options=None, force=False,
     options = resolve_options(options, env_config, topology_class,
                               override_name)
 
+    # Check if we need to maintain virtualenv during the process
+    use_venv = options.get('use_virtualenv', True)
+
+    # Check if user wants to install virtualenv during the process
+    install_venv = options.get('install_virtualenv', use_venv)
+
     # Run pre_submit actions provided by project
     _pre_submit_hooks(override_name, env_name, env_config, options)
 
     # If using virtualenv, set it up, and make sure paths are correct in specs
     if use_venv:
-        virtualenv_name = env_config.get('virtualenv_name', override_name)
+        virtualenv_name = options.get('virtualenv_name', override_name)
         if install_venv:
             create_or_update_virtualenvs(env_name, name, options,
                                          virtualenv_name=virtualenv_name,


### PR DESCRIPTION
This adds a CLI argument to the `submit` command, allowing the user to skip installing virtualenv requirements.

This is especially handy for situations where the virtualenv for a topology is already set up and the topology is getting resubmitted consecutively (e.g. for testing purposes).
This is already achievable via the `install_virtualenv: false` option in `config.json`, but I think a CLI flag that controls that behaviour is useful too.

I've only added it to the `submit` command, and not `update_virtualenv`, as it's rather counter-intuitive to want to run `update_virtualenv` but not install requirements.