### PR TITLE
Fix: respect env config virtualenv_flags

### DIFF
--- a/streamparse/cli/update_virtualenv.py
+++ b/streamparse/cli/update_virtualenv.py
@@ -112,10 +112,12 @@ def create_or_update_virtualenvs(env_name, topology_name, options,
     storm_options = resolve_options(options, env_config, topology_class, topology_name)
     activate_env(env_name, storm_options, config_file=config_file)
 
+    virtualenv_flags = options.get('virtualenv_flags', env_config.get('virtualenv_flags'))
+
     # Actually create or update virtualenv on worker nodes
     execute(_create_or_update_virtualenv, env.virtualenv_root, virtualenv_name,
             requirements_paths,
-            virtualenv_flags=options.get('virtualenv_flags'),
+            virtualenv_flags=virtualenv_flags,
             hosts=env.storm_workers,
             overwrite_virtualenv=overwrite_virtualenv,
             user=user)


### PR DESCRIPTION
This makes the `update_virtualenv` CLI command respect `virtualenv_flags` found in the environment config, while prioritising the respective flags found in options first.

It looks like [this commit](https://github.com/Parsely/streamparse/commit/6271e4cedfca656b0efc16d86c19cd3f95b18c93#diff-1c847440675bda5275c1da1be2382897L99) took away the ability to configure `virtualenv_flags` at the environment level, which silently broke our configuration when creating new virtualenvs.