### PR TITLE
fix error when config_file is set

### DIFF
--- a/streamparse/util.py
+++ b/streamparse/util.py
@@ -182,7 +182,8 @@ def get_config(config_file=None):
         with open("config.json") as fp:
             config = json.load(fp)
     else:
-        config = json.load(config_file)
+        with open(config_file) as fp:
+            config = json.load(fp)
     _config = config
     return config
 


### PR DESCRIPTION
when a custom config_file path is set, ```get_config``` does not open it.