### PR TITLE
Python 3.9 support via Fabric39 fork.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ _resources/
 .*.un~
 
 \.idea/
+.envrc
+.venv*/

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 cython
 jinja2
-fabric3
+fabric39
 pystorm>=3.1.1
 requests
 ruamel.yaml

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 cython
 jinja2
-fabric39
+Fabric39
 pystorm>=3.1.1
 requests
 ruamel.yaml

--- a/streamparse/version.py
+++ b/streamparse/version.py
@@ -28,5 +28,5 @@ def _safe_int(string):
         return string
 
 
-__version__ = "4.0.0"
+__version__ = "4.1.0"
 VERSION = tuple(_safe_int(x) for x in __version__.split("."))


### PR DESCRIPTION
This switches `streamparse` over to Parsely's [Fabric39 fork](https://github.com/parsely/fabric) of  [Fabric3](https://github.com/mathiasertl/fabric) in order to provide backwards-compatible support for Python 3.9.X.  `Fabric39` is publicly available on pypi now [here](https://pypi.org/project/Fabric39/).