### PR TITLE
raise exception on any non-zero exit code from subprocesses

### DIFF
--- a/streamparse/util.py
+++ b/streamparse/util.py
@@ -599,5 +599,5 @@ def run_cmd(cmd, user, **kwargs):
                 else sudo(cmd, user=user, **kwargs)
             )
     if command_result.return_code != 0:
-        raise ValueError()
+        raise RuntimeError('Command failed to run: %s' % cmd)
     return command_result

--- a/streamparse/util.py
+++ b/streamparse/util.py
@@ -592,6 +592,12 @@ def set_topology_serializer(env_config, config, topology_class):
 
 def run_cmd(cmd, user, **kwargs):
     with show("everything"):
-        return (
-            run(cmd, **kwargs) if user == env.user else sudo(cmd, user=user, **kwargs)
-        )
+        with settings(warn_only=True):
+            command_result = (
+                run(cmd, **kwargs)
+                if user == env.user
+                else sudo(cmd, user=user, **kwargs)
+            )
+    if command_result.return_code != 0:
+        raise ValueError()
+    return command_result

--- a/streamparse/version.py
+++ b/streamparse/version.py
@@ -28,5 +28,5 @@ def _safe_int(string):
         return string
 
 
-__version__ = "4.1.1"
+__version__ = "4.1.2"
 VERSION = tuple(_safe_int(x) for x in __version__.split("."))


### PR DESCRIPTION
This pull request causes most streamparse subprocesses to raise exceptions when they return nonzero exit codes. Combined with https://github.com/Parsely/fabric/pull/4, this causes streamparse-based topology deployments to exit when the virtualenv installation fails on one or more hosts.