### PR TITLE
docs: fix simple typo, suport -> support

### DIFF
--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -24,7 +24,7 @@ Components
 Both :class:`streamparse.Bolt` and :class:`streamparse.Spout` inherit from a
 common base-class, :class:`streamparse.storm.component.Component`.  It extends
 pystorm's code for handling `Multi-Lang IPC between Storm and Python <https://storm.apache.org/documentation/Multilang-protocol.html>`__
-and adds suport for our Python :ref:`topology_dsl`.
+and adds support for our Python :ref:`topology_dsl`.
 
 Spouts
 ^^^^^^


### PR DESCRIPTION
There is a small typo in doc/source/api.rst.

Should read `support` rather than `suport`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md